### PR TITLE
Occlusion culling with occlusion query

### DIFF
--- a/occlusion.html
+++ b/occlusion.html
@@ -425,12 +425,7 @@
 
         gl.bindVertexArray(null);
 
-
-        // var NUM_NODES = 32;
-        // var NUM_NODES = 64;
-        // var NUM_NODES = 128;
-        var NUM_NODES = 320;
-        // var NUM_NODES = 512;
+        var NUM_NODES = 512;
         var NUM_PER_ROW = 8;
         var RADIUS = 0.6;
         var nodes = new Array(NUM_NODES);
@@ -456,7 +451,9 @@
 
                     bbox: sphere.bbox,
                     vaobbox: sphereBBoxArray,
-                    bboxNumVertices: sphere.bbox.bbox.positions.length / 3
+                    bboxNumVertices: sphere.bbox.bbox.positions.length / 3,
+
+                    query: gl.createQuery()
                 };
             } else {
                 // sphere high
@@ -471,12 +468,11 @@
 
                     bbox: sphereHigh.bbox,
                     vaobbox: sphereHighBBoxArray,
-                    bboxNumVertices: sphereHigh.bbox.bbox.positions.length / 3
+                    bboxNumVertices: sphereHigh.bbox.bbox.positions.length / 3,
+
+                    query: gl.createQuery()
                 };
             }
-
-            // query object
-            nodes[i].query = gl.createQuery();
             
         }
 
@@ -556,6 +552,9 @@
         var image = new Image();
         var firstFrame = true;
         var isDrawNodes = new Array(nodes.length);
+        for (var i = 0, len = isDrawNodes.length; i < len; ++i) {
+            isDrawNodes[i] = true;
+        }
         var invisibleNodesCount = 0;
 
         image.onload = function() {
@@ -584,10 +583,8 @@
             var rotationMatrix = mat4.create();
             var node, bbox, isVisible = true;
             var doquery = true;
-
-            for (var i = 0, len = isDrawNodes.length; i < len; ++i) {
-                isDrawNodes[i] = true;
-            }
+            var samplesPassed;
+            
 
             var t = 0;
             function draw() {
@@ -623,29 +620,28 @@
 
                         gl.uniformMatrix4fv(modelMatrixLocationBBox, false, node.modelMatrix);
                         
-                        isVisible = true;
-                        isDrawNodes[i] = true;
+                        // isDrawNodes[i] = true;
                         doquery = true;
 
                         if (!firstFrame) {
                             if (gl.getQueryParameter(node.query, gl.QUERY_RESULT_AVAILABLE)) {
                                 // A query's result is never available in the same frame
                                 // the query was issued.  Try in the next frame.
-                                var samplesPassed = gl.getQueryParameter(node.query, gl.QUERY_RESULT);
+                                samplesPassed = gl.getQueryParameter(node.query, gl.QUERY_RESULT);
 
                                 if (samplesPassed == 0) {
                                     // console.log('invisible node ' + i);
                                     isVisible = false;
                                     isDrawNodes[i] = false;
-                                    invisibleNodesCount++;
                                 }
-                                // else
-                                // {
-                                //     // console.log('!!!visible node ' + i);
-                                //     visibleNodesCount++;
-                                // }
+                                else {
+                                    isVisible = true;
+                                    isDrawNodes[i] = true;
+                                }
                             } 
                             else {
+                                // query is not ready, use visible info from previous frame (to make assist cam looks correct)
+                                // if we want to be conservative, simple set isVisible to true
                                 isVisible = isDrawNodes[i];
                                 doquery = false;
                             }
@@ -655,6 +651,10 @@
                             gl.beginQuery(gl.ANY_SAMPLES_PASSED_CONSERVATIVE, node.query);
                             gl.drawArrays(gl.TRIANGLES, 0, node.bboxNumVertices);
                             gl.endQuery(gl.ANY_SAMPLES_PASSED_CONSERVATIVE);
+                        }
+
+                        if (!isVisible) {
+                            invisibleNodesCount++;
                         }
                         
                     }
@@ -668,11 +668,7 @@
 
                         gl.uniformMatrix4fv(modelMatrixLocation, false, node.modelMatrix);
 
-                        if (node.indicesLength) {
-                            gl.drawElements(gl.TRIANGLES, node.indicesLength, gl.UNSIGNED_SHORT, 0);
-                        } else {
-                            gl.drawArrays(gl.TRIANGLES, 0, node.numVertices);
-                        }
+                        gl.drawElements(gl.TRIANGLES, node.indicesLength, gl.UNSIGNED_SHORT, 0);
                     }
                     
                     
@@ -711,11 +707,7 @@
                             node = nodes[i];
                             gl.bindVertexArray(node.vao);
                             gl.uniformMatrix4fv(modelMatrixLocationAssistCam, false, node.modelMatrix);
-                            if (node.indicesLength) {
-                                gl.drawElements(gl.TRIANGLES, node.indicesLength, gl.UNSIGNED_SHORT, 0);
-                            } else {
-                                gl.drawArrays(gl.TRIANGLES, 0, node.numVertices);
-                            }
+                            gl.drawElements(gl.TRIANGLES, node.indicesLength, gl.UNSIGNED_SHORT, 0);
                         }
                     }
                     gl.disable(gl.SCISSOR_TEST);

--- a/occlusion.html
+++ b/occlusion.html
@@ -275,8 +275,6 @@
             console.error(gl.getProgramInfoLog(programBBox));
         }
 
-
-
         var vsSourceAssistCam =  document.getElementById("vertex-assist-cam").text.trim();
         var fsSourceAssistCam =  document.getElementById("fragment-assist-cam").text.trim();
 
@@ -493,6 +491,18 @@
             
         }
 
+        nodes.sort(function(a, b){
+            var z = a.translate.z - b.translate.z;
+            if (z !== 0) {
+                return z;
+            }
+            var x = a.translate.x - b.translate.x;
+            if (x !== 0) {
+                return x;
+            }
+            return a.translate.y - b.translate.y;
+        });
+
         //////////////////////////
         // UNIFORM DATA
         //////////////////////////
@@ -587,6 +597,7 @@
                 isDrawNodes[i] = true;
             }
 
+            var t = 0;
             function draw() {
                 // angleX += 0.01;
                 // angleY += 0.02;
@@ -599,7 +610,7 @@
 
                 // gl.clear(gl.COLOR_BUFFER_BIT);
                 // gl.drawArrays(gl.TRIANGLES, 0, numVertices);
-                
+                t += 0.01;
                 invisibleNodesCount = 0;
 
                 gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
@@ -616,7 +627,8 @@
                     node = nodes[i];
                     bbox = node.bbox;
 
-                    node.rotate[1] += 0.01;
+                    // node.rotate[1] += 0.01;
+                    node.rotate[1] = Math.PI / 6 * (Math.sin(t - Math.PI / 2) + 1);
 
                     utils.xformMatrix(node.modelMatrix, node.translate, null, node.scale);
                     mat4.fromYRotation(rotationMatrix, node.rotate[1]);

--- a/occlusion.html
+++ b/occlusion.html
@@ -113,7 +113,38 @@
             fragColor = vec4(color * (diffuse + highlight + ambient), 1.0);
         }
     </script>
-        <script type="text/javascript">
+    <script type="x-shader/vs" id="vertex-bbox">
+        #version 300 es
+
+        layout(std140, column_major) uniform;
+        
+        layout(location=0) in vec4 position;
+        
+        uniform SceneUniforms {
+            mat4 viewProj;
+            vec4 eyePosition;
+            vec4 lightPosition;
+        } uScene;       
+        
+        uniform mat4 uModel;
+
+        void main() {
+            gl_Position = uScene.viewProj * uModel * position;
+        }
+    </script>
+    <script type="x-shader/vf" id="fragment-bbox">
+        #version 300 es
+        precision highp float;
+
+        layout(std140, column_major) uniform;
+
+        out vec4 fragColor;
+
+        void main() {
+            fragColor = vec4(1.0, 1.0, 1.0, 1.0);
+        }
+    </script>
+    <script type="text/javascript">
         var canvas = document.getElementById("gl-canvas");
         canvas.width = window.innerWidth;
         canvas.height = window.innerHeight;
@@ -160,6 +191,36 @@
             console.error(gl.getProgramInfoLog(program));
         }
 
+
+
+        var vsSourceBBox =  document.getElementById("vertex-bbox").text.trim();
+        var fsSourceBBox =  document.getElementById("fragment-bbox").text.trim();
+
+        var vertexShaderBBox = gl.createShader(gl.VERTEX_SHADER);
+        gl.shaderSource(vertexShaderBBox, vsSourceBBox);
+        gl.compileShader(vertexShaderBBox);
+
+        if (!gl.getShaderParameter(vertexShaderBBox, gl.COMPILE_STATUS)) {
+            console.error(gl.getShaderInfoLog(vertexShaderBBox));
+        }
+
+        var fragmentShaderBBox = gl.createShader(gl.FRAGMENT_SHADER);
+        gl.shaderSource(fragmentShaderBBox, fsSourceBBox);
+        gl.compileShader(fragmentShaderBBox);
+
+        if (!gl.getShaderParameter(fragmentShaderBBox, gl.COMPILE_STATUS)) {
+            console.error(gl.getShaderInfoLog(fragmentShaderBBox));
+        }
+
+        var programBBox = gl.createProgram();
+        gl.attachShader(programBBox, vertexShaderBBox);
+        gl.attachShader(programBBox, fragmentShaderBBox);
+        gl.linkProgram(programBBox);
+
+        if (!gl.getProgramParameter(programBBox, gl.LINK_STATUS)) {
+            console.error(gl.getProgramInfoLog(programBBox));
+        }
+
         /////////////////////////
         // GET UNIFORM LOCATIONS
         /////////////////////////
@@ -170,38 +231,99 @@
         var modelMatrixLocation = gl.getUniformLocation(program, "uModel");
         var texLocation = gl.getUniformLocation(program, "tex");
 
-        gl.useProgram(program);
+        // gl.useProgram(program);
+
+
+        var sceneUniformsLocationBBox = gl.getUniformBlockIndex(programBBox, "SceneUniforms");
+        gl.uniformBlockBinding(programBBox, sceneUniformsLocationBBox, 0);
+
+        var modelMatrixLocationBBox = gl.getUniformLocation(programBBox, "uModel");
 
         /////////////////////
         // SET UP GEOMETRY & scene
         /////////////////////
 
-        var box = utils.createBox({dimensions: [1.0, 1.0, 1.0]});
-        // var numVertices = box.positions.length / 3;
+        var positionBuffer, uvBuffer, normalBuffer, indices;
 
-        var cubeArray = gl.createVertexArray();
-        gl.bindVertexArray(cubeArray);
+        // var box = utils.createBox({dimensions: [1.0, 1.0, 1.0]});
+        // // var numVertices = box.positions.length / 3;
 
-        var positionBuffer = gl.createBuffer();
+        // var cubeArray = gl.createVertexArray();
+        // gl.bindVertexArray(cubeArray);
+
+        // var positionBuffer = gl.createBuffer();
+        // gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+        // gl.bufferData(gl.ARRAY_BUFFER, box.positions, gl.STATIC_DRAW);
+        // gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
+        // gl.enableVertexAttribArray(0);
+
+        // var uvBuffer = gl.createBuffer();
+        // gl.bindBuffer(gl.ARRAY_BUFFER, uvBuffer);
+        // gl.bufferData(gl.ARRAY_BUFFER, box.uvs, gl.STATIC_DRAW);
+        // gl.vertexAttribPointer(1, 2, gl.FLOAT, false, 0, 0);
+        // gl.enableVertexAttribArray(1);
+
+        // var normalBuffer = gl.createBuffer();
+        // gl.bindBuffer(gl.ARRAY_BUFFER, normalBuffer);
+        // gl.bufferData(gl.ARRAY_BUFFER, box.normals, gl.STATIC_DRAW);
+        // gl.vertexAttribPointer(2, 3, gl.FLOAT, false, 0, 0);
+        // gl.enableVertexAttribArray(2);
+
+        // gl.bindVertexArray(null);
+
+        // sphere high poly
+
+        var sphereHigh = utils.createSphere({
+            long_bands: 96,
+            lat_bands: 96,
+            radius: 0.6
+        });
+
+        var sphereHighArray = gl.createVertexArray();
+        gl.bindVertexArray(sphereHighArray);
+
+        positionBuffer = gl.createBuffer();
         gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
-        gl.bufferData(gl.ARRAY_BUFFER, box.positions, gl.STATIC_DRAW);
+        gl.bufferData(gl.ARRAY_BUFFER, sphereHigh.positions, gl.STATIC_DRAW);
         gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
         gl.enableVertexAttribArray(0);
 
-        var uvBuffer = gl.createBuffer();
+        uvBuffer = gl.createBuffer();
         gl.bindBuffer(gl.ARRAY_BUFFER, uvBuffer);
-        gl.bufferData(gl.ARRAY_BUFFER, box.uvs, gl.STATIC_DRAW);
+        gl.bufferData(gl.ARRAY_BUFFER, sphereHigh.uvs, gl.STATIC_DRAW);
         gl.vertexAttribPointer(1, 2, gl.FLOAT, false, 0, 0);
         gl.enableVertexAttribArray(1);
 
-        var normalBuffer = gl.createBuffer();
+        normalBuffer = gl.createBuffer();
         gl.bindBuffer(gl.ARRAY_BUFFER, normalBuffer);
-        gl.bufferData(gl.ARRAY_BUFFER, box.normals, gl.STATIC_DRAW);
+        gl.bufferData(gl.ARRAY_BUFFER, sphereHigh.normals, gl.STATIC_DRAW);
         gl.vertexAttribPointer(2, 3, gl.FLOAT, false, 0, 0);
         gl.enableVertexAttribArray(2);
 
+        indices = gl.createBuffer();
+        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indices);
+        gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, sphereHigh.indices, gl.STATIC_DRAW);
+
         gl.bindVertexArray(null);
 
+
+
+        sphereHigh.bbox = utils.computeBoundingBox(sphereHigh.positions, {geo: true});
+
+        var sphereHighBBoxArray = gl.createVertexArray();
+        gl.bindVertexArray(sphereHighBBoxArray);
+
+        positionBuffer = gl.createBuffer();
+        gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+        gl.bufferData(gl.ARRAY_BUFFER, sphereHigh.bbox.bbox.positions, gl.STATIC_DRAW);
+        gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
+        gl.enableVertexAttribArray(0);
+
+        gl.bindVertexArray(null);
+
+
+
+        // sphere low poly
 
         var sphere = utils.createSphere({
             long_bands: 16,
@@ -209,35 +331,52 @@
             radius: 0.5
         });
 
-        sphere.bbox = utils.computeBoundingBox(sphere.positions, {geo: true});
         // var numVertices = sphere.positions.length / 3;
 
         var sphereArray = gl.createVertexArray();
         gl.bindVertexArray(sphereArray);
 
-        var positionBuffer = gl.createBuffer();
+        positionBuffer = gl.createBuffer();
         gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
         gl.bufferData(gl.ARRAY_BUFFER, sphere.positions, gl.STATIC_DRAW);
         gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
         gl.enableVertexAttribArray(0);
 
-        var uvBuffer = gl.createBuffer();
+        uvBuffer = gl.createBuffer();
         gl.bindBuffer(gl.ARRAY_BUFFER, uvBuffer);
         gl.bufferData(gl.ARRAY_BUFFER, sphere.uvs, gl.STATIC_DRAW);
         gl.vertexAttribPointer(1, 2, gl.FLOAT, false, 0, 0);
         gl.enableVertexAttribArray(1);
 
-        var normalBuffer = gl.createBuffer();
+        normalBuffer = gl.createBuffer();
         gl.bindBuffer(gl.ARRAY_BUFFER, normalBuffer);
         gl.bufferData(gl.ARRAY_BUFFER, sphere.normals, gl.STATIC_DRAW);
         gl.vertexAttribPointer(2, 3, gl.FLOAT, false, 0, 0);
         gl.enableVertexAttribArray(2);
 
-        var indices = gl.createBuffer();
+        indices = gl.createBuffer();
         gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indices);
         gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, sphere.indices, gl.STATIC_DRAW);
 
         gl.bindVertexArray(null);
+
+
+
+        sphere.bbox = utils.computeBoundingBox(sphere.positions, {geo: true});
+
+        var sphereBBoxArray = gl.createVertexArray();
+        gl.bindVertexArray(sphereBBoxArray);
+
+        positionBuffer = gl.createBuffer();
+        gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+        gl.bufferData(gl.ARRAY_BUFFER, sphere.bbox.bbox.positions, gl.STATIC_DRAW);
+        gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
+        gl.enableVertexAttribArray(0);
+
+        gl.bindVertexArray(null);
+
+
+
 
         var NUM_NODES = 32;
         var NUM_PER_ROW = 8;
@@ -251,7 +390,7 @@
             var z = Math.cos(angle) * RADIUS;
 
             if (i % 2 == 0) {
-                // sphere
+                // sphere low
                 nodes[i] = {
                     scale: [0.8, 0.8, 0.8],
                     rotate: [0, 0, 0], // Will be used for global rotation
@@ -259,20 +398,42 @@
                     modelMatrix: mat4.create(),
 
                     vao: sphereArray,
-                    indicesLength: sphere.indices.length
+                    indicesLength: sphere.indices.length,
+
+                    bbox: sphere.bbox,
+                    vaobbox: sphereBBoxArray,
+                    bboxNumVertices: sphere.bbox.bbox.positions.length / 3
                 };
             } else {
-                // cube
+                // // cube
+                // nodes[i] = {
+                //     scale: [0.4, 0.4, 0.4],
+                //     rotate: [0, 0, 0], // Will be used for global rotation
+                //     translate: [x, y, z],
+                //     modelMatrix: mat4.create(),
+
+                //     vao: cubeArray,
+                //     numVertices: box.positions.length / 3
+                // }
+
+                // sphere high
                 nodes[i] = {
-                    scale: [0.4, 0.4, 0.4],
+                    scale: [0.8, 0.8, 0.8],
                     rotate: [0, 0, 0], // Will be used for global rotation
                     translate: [x, y, z],
                     modelMatrix: mat4.create(),
 
-                    vao: cubeArray,
-                    numVertices: box.positions.length / 3
-                }
+                    vao: sphereHighArray,
+                    indicesLength: sphereHigh.indices.length,
+
+                    bbox: sphereHigh.bbox,
+                    vaobbox: sphereHighBBoxArray,
+                    bboxNumVertices: sphereHigh.bbox.bbox.positions.length / 3
+                };
             }
+
+            // query object
+            nodes[i].query = gl.createQuery();
             
         }
 
@@ -328,10 +489,11 @@
             gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, image.width, image.height, gl.RGBA, gl.UNSIGNED_BYTE, image);
             gl.generateMipmap(gl.TEXTURE_2D);
 
+            gl.useProgram(program);
             gl.uniform1i(texLocation, 0);
 
             var rotationMatrix = mat4.create();
-            var node;
+            var node, bbox;
 
             function draw() {
                 // angleX += 0.01;
@@ -350,22 +512,52 @@
 
                 for (var i = 0, len = nodes.length; i < len; ++i) {
                     node = nodes[i];
-                    gl.bindVertexArray(node.vao);
+                    bbox = node.bbox;
 
                     node.rotate[1] += 0.002;
 
                     utils.xformMatrix(node.modelMatrix, node.translate, null, node.scale);
                     mat4.fromYRotation(rotationMatrix, node.rotate[1]);
                     mat4.multiply(node.modelMatrix, rotationMatrix, node.modelMatrix);
-                
-                    gl.uniformMatrix4fv(modelMatrixLocation, false, node.modelMatrix);
-                    // modelMatrixData.set(node.modelMatrix, i * 16);
 
-                    if (node.indicesLength) {
-                        gl.drawElements(gl.TRIANGLES, node.indicesLength, gl.UNSIGNED_SHORT, 0);
-                    } else {
-                        gl.drawArrays(gl.TRIANGLES, 0, node.numVertices);
+                    
+
+                    // use occlusion query with drawing bounding box
+                    // gl.colorMask(false, false, false, false);
+                    // gl.depthMask(false);
+                    gl.useProgram(programBBox);
+                    gl.bindVertexArray(node.vaobbox);
+
+                    gl.uniformMatrix4fv(modelMatrixLocationBBox, false, node.modelMatrix);
+                    
+                    gl.beginQuery(gl.ANY_SAMPLES_PASSED, node.query);
+                    gl.drawArrays(gl.TRIANGLES, 0, node.bboxNumVertices);
+                    gl.endQuery(gl.ANY_SAMPLES_PASSED);
+
+                    if (gl.getQueryParameter(node.query, gl.QUERY_RESULT_AVAILABLE)) {
+                        // A query's result is never available in the same frame
+                        // the query was issued.  Try in the next frame.
+                        var samplesPassed = gl.getQueryParameter(node.query, gl.QUERY_RESULT);
+
+                        if (samplesPassed == 0) {
+                            console.log('invisible node ' + i);
+                            continue;
+                        }
                     }
+
+                    // gl.colorMask(true, true, true, true);
+                    // gl.depthMask(true);
+                    // gl.useProgram(program);
+                    // gl.bindVertexArray(node.vao);
+
+                    // gl.uniformMatrix4fv(modelMatrixLocation, false, node.modelMatrix);
+                    // // modelMatrixData.set(node.modelMatrix, i * 16);
+
+                    // if (node.indicesLength) {
+                    //     gl.drawElements(gl.TRIANGLES, node.indicesLength, gl.UNSIGNED_SHORT, 0);
+                    // } else {
+                    //     gl.drawArrays(gl.TRIANGLES, 0, node.numVertices);
+                    // }
                     
                 }
                 

--- a/occlusion.html
+++ b/occlusion.html
@@ -322,59 +322,9 @@
 
         var positionBuffer, uvBuffer, normalBuffer, indices;
 
-        // sphere high poly
-
-        var sphereHigh = utils.createSphere({
-            long_bands: 128,
-            lat_bands: 128,
-            radius: 0.6
-        });
-
-        var sphereHighArray = gl.createVertexArray();
-        gl.bindVertexArray(sphereHighArray);
-
-        positionBuffer = gl.createBuffer();
-        gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
-        gl.bufferData(gl.ARRAY_BUFFER, sphereHigh.positions, gl.STATIC_DRAW);
-        gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
-        gl.enableVertexAttribArray(0);
-
-        uvBuffer = gl.createBuffer();
-        gl.bindBuffer(gl.ARRAY_BUFFER, uvBuffer);
-        gl.bufferData(gl.ARRAY_BUFFER, sphereHigh.uvs, gl.STATIC_DRAW);
-        gl.vertexAttribPointer(1, 2, gl.FLOAT, false, 0, 0);
-        gl.enableVertexAttribArray(1);
-
-        normalBuffer = gl.createBuffer();
-        gl.bindBuffer(gl.ARRAY_BUFFER, normalBuffer);
-        gl.bufferData(gl.ARRAY_BUFFER, sphereHigh.normals, gl.STATIC_DRAW);
-        gl.vertexAttribPointer(2, 3, gl.FLOAT, false, 0, 0);
-        gl.enableVertexAttribArray(2);
-
-        indices = gl.createBuffer();
-        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indices);
-        gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, sphereHigh.indices, gl.STATIC_DRAW);
-
-        gl.bindVertexArray(null);
-
-        sphereHigh.bbox = utils.computeBoundingBox(sphereHigh.positions, {geo: true});
-
-        var sphereHighBBoxArray = gl.createVertexArray();
-        gl.bindVertexArray(sphereHighBBoxArray);
-
-        positionBuffer = gl.createBuffer();
-        gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
-        gl.bufferData(gl.ARRAY_BUFFER, sphereHigh.bbox.bbox.positions, gl.STATIC_DRAW);
-        gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
-        gl.enableVertexAttribArray(0);
-
-        gl.bindVertexArray(null);
-
-        // sphere low poly
-
         var sphere = utils.createSphere({
-            long_bands: 64,
-            lat_bands: 64,
+            long_bands: 96,
+            lat_bands: 96,
             radius: 0.5
         });
 
@@ -429,55 +379,24 @@
             var y = (Math.floor(i / NUM_PER_ROW) % 4) / (NUM_PER_ROW / 4) - 0.75;
             var z = Math.cos(angle) * RADIUS - 2 * Math.floor(i / 32 % 4);
 
-            if (i % 2 == 0) {
-                // sphere low
-                nodes[i] = {
-                    scale: [0.8, 0.8, 0.8],
-                    rotate: [0, 0, 0], // Will be used for global rotation
-                    translate: [x, y, z],
-                    modelMatrix: mat4.create(),
+            nodes[i] = {
+                scale: [0.8, 0.8, 0.8],
+                rotate: [0, 0, 0], // Will be used for global rotation
+                translate: [x, y, z],
+                modelMatrix: mat4.create(),
 
-                    vao: sphereArray,
-                    indicesLength: sphere.indices.length,
+                vao: sphereArray,
+                indicesLength: sphere.indices.length,
 
-                    bbox: sphere.bbox,
-                    vaobbox: sphereBBoxArray,
-                    bboxNumVertices: sphere.bbox.bbox.positions.length / 3,
+                bbox: sphere.bbox,
+                vaobbox: sphereBBoxArray,
+                bboxNumVertices: sphere.bbox.bbox.positions.length / 3,
 
-                    query: gl.createQuery()
-                };
-            } else {
-                // sphere high
-                nodes[i] = {
-                    scale: [0.8, 0.8, 0.8],
-                    rotate: [0, 0, 0], // Will be used for global rotation
-                    translate: [x, y, z],
-                    modelMatrix: mat4.create(),
-
-                    vao: sphereHighArray,
-                    indicesLength: sphereHigh.indices.length,
-
-                    bbox: sphereHigh.bbox,
-                    vaobbox: sphereHighBBoxArray,
-                    bboxNumVertices: sphereHigh.bbox.bbox.positions.length / 3,
-
-                    query: gl.createQuery()
-                };
-            }
+                query: gl.createQuery()
+            };
             
+            utils.xformMatrix(nodes[i].modelMatrix, nodes[i].translate, null, nodes[i].scale);
         }
-
-        nodes.sort(function(a, b){
-            var z = a.translate.z - b.translate.z;
-            if (z !== 0) {
-                return z;
-            }
-            var x = a.translate.x - b.translate.x;
-            if (x !== 0) {
-                return x;
-            }
-            return - a.translate.y + b.translate.y;
-        });
 
         document.getElementById("num-nodes").innerHTML = nodes.length;
 
@@ -496,6 +415,30 @@
 
         var viewProjMatrix = mat4.create();
         mat4.multiply(viewProjMatrix, projMatrix, viewMatrix);
+
+        var tmpVec4a = vec4.create();
+        var tmpVec4b = vec4.create();
+        var tmpMat4 = mat4.create();
+        nodes.sort(function(a, b){
+            // sort nodes by dist to eye (via pos in view space)
+            // we assume their relative order is static in this demo
+            vec4.set(tmpVec4a, a.translate.x, a.translate.y, a.translate.z, 1.0);
+            vec4.set(tmpVec4b, b.translate.x, b.translate.y, b.translate.z, 1.0);
+
+            mat4.mul(tmpMat4, viewMatrix, a.modelMatrix);
+            vec4.transformMat4(tmpVec4a, tmpVec4a, tmpMat4);
+            mat4.mul(tmpMat4, viewMatrix, b.modelMatrix);
+            vec4.transformMat4(tmpVec4b, tmpVec4b, tmpMat4);
+            
+            vec4.sub(tmpVec4a, tmpVec4a, tmpVec4b);
+            if (tmpVec4a[0] !== 0) {
+                return tmpVec4a[0];
+            }
+            if (tmpVec4a[2] !== 0) {
+                return tmpVec4a[2];
+            }
+            return -tmpVec4a[1];
+        });
 
         // top down assist camera
         var projMatrixAssistCam = mat4.create();
@@ -555,7 +498,7 @@
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.REPEAT);
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.REPEAT);
 
-            var levels = levels = Math.floor(Math.log2(Math.max(this.width, this.height))) + 1;
+            var levels = Math.floor(Math.log2(Math.max(this.width, this.height))) + 1;
             gl.texStorage2D(gl.TEXTURE_2D, levels, gl.RGBA8, image.width, image.height);
             gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, image.width, image.height, gl.RGBA, gl.UNSIGNED_BYTE, image);
             gl.generateMipmap(gl.TEXTURE_2D);

--- a/occlusion.html
+++ b/occlusion.html
@@ -1,0 +1,359 @@
+<!DOCTYPE html>
+<!--
+  The MIT License (MIT)
+
+  Copyright (c) 2017 Tarek Sherif
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of
+  this software and associated documentation files (the "Software"), to deal in
+  the Software without restriction, including without limitation the rights to
+  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+  the Software, and to permit persons to whom the Software is furnished to do so,
+  subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+-->
+<!-- 
+    SSAO algorithm from http://www.nutty.ca/?page_id=352&link=ssao
+ -->
+<html>
+<head>
+    <title>WebGL 2 Example: Occlusion culling using occlusion query</title>
+    <script src="utils/gl-matrix.js"></script>
+    <script src="utils/utils.js"></script>
+    <link rel="stylesheet" href="css/webgl2examples.css">
+    <style>
+        #ssao-controls {
+            position: absolute;
+            bottom: 20px;
+            right: 20px;
+            color: white;
+        }
+    </style>
+</head>
+<body>
+    <div id="example-title">
+        <header>WebGL 2 Example: Occlusion culling using occlusion query</header>
+        <div id="features">
+            Features: Vertex Arrays, Uniform Buffers, Immutable Textures, Occlusion Query
+        </div>
+        <div>
+            <a href="https://github.com/tsherif/webgl2examples/blob/master/ssao.html">Source code</a>
+        </div>
+    </div>
+    <canvas id="gl-canvas"></canvas>
+    <div id="ssao-controls">
+        Enable Occlusion Culling: <input id="ssao-toggle" type="checkbox" checked>
+    </div>
+    <script type="x-shader/vs" id="vertex-draw">
+        #version 300 es
+
+        layout(std140, column_major) uniform;
+        
+        layout(location=0) in vec4 position;
+        layout(location=1) in vec2 uv;
+        layout(location=2) in vec4 normal;
+        
+        uniform SceneUniforms {
+            mat4 viewProj;
+            vec4 eyePosition;
+            vec4 lightPosition;
+        } uScene;       
+        
+        uniform mat4 uModel;
+
+        out  vec3 vPosition;
+        out  vec2 vUV;
+        flat out  vec3 vNormal;
+        void main() {
+            vec4 worldPosition = uModel * position;
+            vPosition = worldPosition.xyz;
+            vUV = uv;
+            vNormal = (uModel * normal).xyz;
+            gl_Position = uScene.viewProj * worldPosition;
+        }
+    </script>
+    <script type="x-shader/vf" id="fragment-draw">
+        #version 300 es
+        precision highp float;
+
+        layout(std140, column_major) uniform;
+
+        uniform SceneUniforms {
+            mat4 viewProj;
+            vec4 eyePosition;
+            vec4 lightPosition;
+        } uScene;
+
+        uniform sampler2D tex;
+        
+        in vec3 vPosition;
+        in vec2 vUV;
+        flat in vec3 vNormal;
+
+        out vec4 fragColor;
+        void main() {
+            vec3 color = texture(tex, vUV).rgb;
+
+            vec3 normal = normalize(vNormal);
+            vec3 eyeVec = normalize(uScene.eyePosition.xyz - vPosition);
+            vec3 incidentVec = normalize(vPosition - uScene.lightPosition.xyz);
+            vec3 lightVec = -incidentVec;
+            float diffuse = max(dot(lightVec, normal), 0.0);
+            float highlight = pow(max(dot(eyeVec, reflect(incidentVec, normal)), 0.0), 100.0);
+            float ambient = 0.1;
+            fragColor = vec4(color * (diffuse + highlight + ambient), 1.0);
+        }
+    </script>
+        <script type="text/javascript">
+        var canvas = document.getElementById("gl-canvas");
+        canvas.width = window.innerWidth;
+        canvas.height = window.innerHeight;
+        
+        var gl = canvas.getContext("webgl2");
+        if (!gl) {
+            console.error("WebGL 2 not available");
+            document.body.innerHTML = "This example requires WebGL 2 which is unavailable on this system."
+        }
+
+        gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
+        gl.clearColor(0.0, 0.0, 0.0, 1.0)
+        gl.enable(gl.DEPTH_TEST);
+
+        /////////////////////
+        // SET UP PROGRAM
+        /////////////////////
+
+        var vsSource =  document.getElementById("vertex-draw").text.trim();
+        var fsSource =  document.getElementById("fragment-draw").text.trim();
+
+        var vertexShader = gl.createShader(gl.VERTEX_SHADER);
+        gl.shaderSource(vertexShader, vsSource);
+        gl.compileShader(vertexShader);
+
+        if (!gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS)) {
+            console.error(gl.getShaderInfoLog(vertexShader));
+        }
+
+        var fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
+        gl.shaderSource(fragmentShader, fsSource);
+        gl.compileShader(fragmentShader);
+
+        if (!gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS)) {
+            console.error(gl.getShaderInfoLog(fragmentShader));
+        }
+
+        var program = gl.createProgram();
+        gl.attachShader(program, vertexShader);
+        gl.attachShader(program, fragmentShader);
+        gl.linkProgram(program);
+
+        if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+            console.error(gl.getProgramInfoLog(program));
+        }
+
+        /////////////////////////
+        // GET UNIFORM LOCATIONS
+        /////////////////////////
+
+        var sceneUniformsLocation = gl.getUniformBlockIndex(program, "SceneUniforms");
+        gl.uniformBlockBinding(program, sceneUniformsLocation, 0);
+
+        var modelMatrixLocation = gl.getUniformLocation(program, "uModel");
+        var texLocation = gl.getUniformLocation(program, "tex");
+
+        gl.useProgram(program);
+
+        /////////////////////
+        // SET UP GEOMETRY & scene
+        /////////////////////
+
+        // var box = utils.createBox({dimensions: [1.0, 1.0, 1.0]});
+        // var numVertices = box.positions.length / 3;
+
+        // var cubeArray = gl.createVertexArray();
+        // gl.bindVertexArray(cubeArray);
+
+        // var positionBuffer = gl.createBuffer();
+        // gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+        // gl.bufferData(gl.ARRAY_BUFFER, box.positions, gl.STATIC_DRAW);
+        // gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
+        // gl.enableVertexAttribArray(0);
+
+        // var uvBuffer = gl.createBuffer();
+        // gl.bindBuffer(gl.ARRAY_BUFFER, uvBuffer);
+        // gl.bufferData(gl.ARRAY_BUFFER, box.uvs, gl.STATIC_DRAW);
+        // gl.vertexAttribPointer(1, 2, gl.FLOAT, false, 0, 0);
+        // gl.enableVertexAttribArray(1);
+
+        // var normalBuffer = gl.createBuffer();
+        // gl.bindBuffer(gl.ARRAY_BUFFER, normalBuffer);
+        // gl.bufferData(gl.ARRAY_BUFFER, box.normals, gl.STATIC_DRAW);
+        // gl.vertexAttribPointer(2, 3, gl.FLOAT, false, 0, 0);
+        // gl.enableVertexAttribArray(2);
+
+        var sphere = utils.createSphere({
+            long_bands: 16,
+            lat_bands: 16,
+            radius: 0.5
+        });
+        var numVertices = sphere.positions.length / 3;
+
+        var sphereArray = gl.createVertexArray();
+        gl.bindVertexArray(sphereArray);
+
+        var positionBuffer = gl.createBuffer();
+        gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+        gl.bufferData(gl.ARRAY_BUFFER, sphere.positions, gl.STATIC_DRAW);
+        gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
+        gl.enableVertexAttribArray(0);
+
+        var uvBuffer = gl.createBuffer();
+        gl.bindBuffer(gl.ARRAY_BUFFER, uvBuffer);
+        gl.bufferData(gl.ARRAY_BUFFER, sphere.uvs, gl.STATIC_DRAW);
+        gl.vertexAttribPointer(1, 2, gl.FLOAT, false, 0, 0);
+        gl.enableVertexAttribArray(1);
+
+        var normalBuffer = gl.createBuffer();
+        gl.bindBuffer(gl.ARRAY_BUFFER, normalBuffer);
+        gl.bufferData(gl.ARRAY_BUFFER, sphere.normals, gl.STATIC_DRAW);
+        gl.vertexAttribPointer(2, 3, gl.FLOAT, false, 0, 0);
+        gl.enableVertexAttribArray(2);
+
+        var indices = gl.createBuffer();
+        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indices);
+        gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, sphere.indices, gl.STATIC_DRAW);
+
+        gl.bindVertexArray(null);
+
+        var NUM_SPHERES = 32;
+        var NUM_PER_ROW = 8;
+        var RADIUS = 0.6;
+        var nodes = new Array(NUM_SPHERES);
+
+        for (var i = 0; i < NUM_SPHERES; ++i) {
+            var angle = 2 * Math.PI * (i % NUM_PER_ROW) / NUM_PER_ROW;
+            var x = Math.sin(angle) * RADIUS;
+            var y = Math.floor(i / NUM_PER_ROW) / (NUM_PER_ROW / 4) - 0.75;
+            var z = Math.cos(angle) * RADIUS;
+            nodes[i] = {
+                scale: [0.8, 0.8, 0.8],
+                rotate: [0, 0, 0], // Will be used for global rotation
+                translate: [x, y, z],
+                modelMatrix: mat4.create(),
+
+                vao: sphereArray,
+                indicesLength: sphere.indices.length
+            };
+        }
+
+        //////////////////////////
+        // UNIFORM DATA
+        //////////////////////////
+
+        var projMatrix = mat4.create();
+        mat4.perspective(projMatrix, Math.PI / 2, gl.drawingBufferWidth / gl.drawingBufferHeight, 0.1, 10.0);
+
+        var viewMatrix = mat4.create();
+        // var eyePosition = vec3.fromValues(1, 1, 1);
+        var eyePosition = vec3.fromValues(0, 0.8, 2);
+        mat4.lookAt(viewMatrix, eyePosition, vec3.fromValues(0, 0, 0), vec3.fromValues(0, 1, 0));
+
+        var viewProjMatrix = mat4.create();
+        mat4.multiply(viewProjMatrix, projMatrix, viewMatrix);
+
+        // var lightPosition = vec3.fromValues(1, 1, 0.5);
+        var lightPosition = vec3.fromValues(1, 1, 2);
+
+        var modelMatrix = mat4.create();
+        var rotateXMatrix = mat4.create();
+        var rotateYMatrix = mat4.create();
+
+        var sceneUniformData = new Float32Array(24);
+        sceneUniformData.set(viewProjMatrix);
+        sceneUniformData.set(eyePosition, 16);
+        sceneUniformData.set(lightPosition, 20);
+
+        var sceneUniformBuffer = gl.createBuffer();
+        gl.bindBufferBase(gl.UNIFORM_BUFFER, 0, sceneUniformBuffer);
+        gl.bufferData(gl.UNIFORM_BUFFER, sceneUniformData, gl.STATIC_DRAW);
+
+        var angleX = 0;
+        var angleY = 0;
+
+        var image = new Image();
+
+        image.onload = function() {
+            var texture = gl.createTexture();
+            gl.activeTexture(gl.TEXTURE0);
+            gl.bindTexture(gl.TEXTURE_2D, texture);
+
+            gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.REPEAT);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.REPEAT);
+
+            var levels = levels = Math.floor(Math.log2(Math.max(this.width, this.height))) + 1;
+            gl.texStorage2D(gl.TEXTURE_2D, levels, gl.RGBA8, image.width, image.height);
+            gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, image.width, image.height, gl.RGBA, gl.UNSIGNED_BYTE, image);
+            gl.generateMipmap(gl.TEXTURE_2D);
+
+            gl.uniform1i(texLocation, 0);
+
+            var rotationMatrix = mat4.create();
+            var node;
+
+            function draw() {
+                // angleX += 0.01;
+                // angleY += 0.02;
+
+                // mat4.fromXRotation(rotateXMatrix, angleX);
+                // mat4.fromYRotation(rotateYMatrix, angleY);
+                // mat4.multiply(modelMatrix, rotateXMatrix, rotateYMatrix);
+
+                // gl.uniformMatrix4fv(modelMatrixLocation, false, modelMatrix);
+
+                // gl.clear(gl.COLOR_BUFFER_BIT);
+                // gl.drawArrays(gl.TRIANGLES, 0, numVertices);
+
+                gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
+                for (var i = 0, len = nodes.length; i < len; ++i) {
+                    node = nodes[i];
+                    gl.bindVertexArray(node.vao);
+
+                    node.rotate[1] += 0.002;
+
+                    utils.xformMatrix(node.modelMatrix, node.translate, null, node.scale);
+                    mat4.fromYRotation(rotationMatrix, node.rotate[1]);
+                    mat4.multiply(node.modelMatrix, rotationMatrix, node.modelMatrix);
+                
+                    gl.uniformMatrix4fv(modelMatrixLocation, false, node.modelMatrix);
+                    // modelMatrixData.set(node.modelMatrix, i * 16);
+
+                    gl.drawElements(gl.TRIANGLES, node.indicesLength, gl.UNSIGNED_SHORT, 0);
+                }
+                
+
+                requestAnimationFrame(draw);
+            }
+
+            requestAnimationFrame(draw);
+            
+        }
+
+        image.src = "img/khronos_webgl.png";
+
+    </script>
+    <a href="https://github.com/tsherif/webgl2examples" id="github-ribbon"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
+</body>
+</html>

--- a/occlusion.html
+++ b/occlusion.html
@@ -144,6 +144,35 @@
             fragColor = vec4(1.0, 1.0, 1.0, 1.0);
         }
     </script>
+    <script type="x-shader/vs" id="vertex-assist-cam">
+        #version 300 es
+
+        layout(std140, column_major) uniform;
+        
+        layout(location=0) in vec4 position;
+        layout(location=1) in vec2 uv;
+        layout(location=2) in vec4 normal;
+        
+        uniform mat4 uViewProj;
+        
+        uniform mat4 uModel;
+
+        void main() {
+            gl_Position = uViewProj * uModel * position;
+        }
+    </script>
+    <script type="x-shader/vf" id="fragment-assist-cam">
+        #version 300 es
+        precision highp float;
+
+        layout(std140, column_major) uniform;
+
+        out vec4 fragColor;
+
+        void main() {
+            fragColor = vec4(1.0, 0.0, 0.0, 0.2);
+        }
+    </script>
     <script type="text/javascript">
         var canvas = document.getElementById("gl-canvas");
         canvas.width = window.innerWidth;
@@ -154,6 +183,14 @@
             console.error("WebGL 2 not available");
             document.body.innerHTML = "This example requires WebGL 2 which is unavailable on this system."
         }
+
+        var assistCamViewport = [
+            0, 
+            0,
+            gl.drawingBufferWidth / 5, 
+            gl.drawingBufferHeight / 5
+        ];
+
 
         gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
         gl.clearColor(0.0, 0.0, 0.0, 1.0)
@@ -221,6 +258,36 @@
             console.error(gl.getProgramInfoLog(programBBox));
         }
 
+
+
+        var vsSourceAssistCam =  document.getElementById("vertex-assist-cam").text.trim();
+        var fsSourceAssistCam =  document.getElementById("fragment-assist-cam").text.trim();
+
+        var vertexShaderAssistCam = gl.createShader(gl.VERTEX_SHADER);
+        gl.shaderSource(vertexShaderAssistCam, vsSourceAssistCam);
+        gl.compileShader(vertexShaderAssistCam);
+
+        if (!gl.getShaderParameter(vertexShaderAssistCam, gl.COMPILE_STATUS)) {
+            console.error(gl.getShaderInfoLog(vertexShaderAssistCam));
+        }
+
+        var fragmentShaderAssistCam = gl.createShader(gl.FRAGMENT_SHADER);
+        gl.shaderSource(fragmentShaderAssistCam, fsSourceAssistCam);
+        gl.compileShader(fragmentShaderAssistCam);
+
+        if (!gl.getShaderParameter(fragmentShaderAssistCam, gl.COMPILE_STATUS)) {
+            console.error(gl.getShaderInfoLog(fragmentShaderAssistCam));
+        }
+
+        var programAssistCam = gl.createProgram();
+        gl.attachShader(programAssistCam, vertexShaderAssistCam);
+        gl.attachShader(programAssistCam, fragmentShaderAssistCam);
+        gl.linkProgram(programAssistCam);
+
+        if (!gl.getProgramParameter(programAssistCam, gl.LINK_STATUS)) {
+            console.error(gl.getProgramInfoLog(programAssistCam));
+        }
+
         /////////////////////////
         // GET UNIFORM LOCATIONS
         /////////////////////////
@@ -231,45 +298,19 @@
         var modelMatrixLocation = gl.getUniformLocation(program, "uModel");
         var texLocation = gl.getUniformLocation(program, "tex");
 
-        // gl.useProgram(program);
-
-
         var sceneUniformsLocationBBox = gl.getUniformBlockIndex(programBBox, "SceneUniforms");
         gl.uniformBlockBinding(programBBox, sceneUniformsLocationBBox, 0);
 
         var modelMatrixLocationBBox = gl.getUniformLocation(programBBox, "uModel");
+
+        var viewProjMatrixLocationAssistCam = gl.getUniformLocation(programAssistCam, "uViewProj");
+        var modelMatrixLocationAssistCam = gl.getUniformLocation(programAssistCam, "uModel");
 
         /////////////////////
         // SET UP GEOMETRY & scene
         /////////////////////
 
         var positionBuffer, uvBuffer, normalBuffer, indices;
-
-        // var box = utils.createBox({dimensions: [1.0, 1.0, 1.0]});
-        // // var numVertices = box.positions.length / 3;
-
-        // var cubeArray = gl.createVertexArray();
-        // gl.bindVertexArray(cubeArray);
-
-        // var positionBuffer = gl.createBuffer();
-        // gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
-        // gl.bufferData(gl.ARRAY_BUFFER, box.positions, gl.STATIC_DRAW);
-        // gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
-        // gl.enableVertexAttribArray(0);
-
-        // var uvBuffer = gl.createBuffer();
-        // gl.bindBuffer(gl.ARRAY_BUFFER, uvBuffer);
-        // gl.bufferData(gl.ARRAY_BUFFER, box.uvs, gl.STATIC_DRAW);
-        // gl.vertexAttribPointer(1, 2, gl.FLOAT, false, 0, 0);
-        // gl.enableVertexAttribArray(1);
-
-        // var normalBuffer = gl.createBuffer();
-        // gl.bindBuffer(gl.ARRAY_BUFFER, normalBuffer);
-        // gl.bufferData(gl.ARRAY_BUFFER, box.normals, gl.STATIC_DRAW);
-        // gl.vertexAttribPointer(2, 3, gl.FLOAT, false, 0, 0);
-        // gl.enableVertexAttribArray(2);
-
-        // gl.bindVertexArray(null);
 
         // sphere high poly
 
@@ -376,8 +417,6 @@
         gl.bindVertexArray(null);
 
 
-
-
         var NUM_NODES = 32;
         var NUM_PER_ROW = 8;
         var RADIUS = 0.6;
@@ -441,6 +480,7 @@
         // UNIFORM DATA
         //////////////////////////
 
+        // scene main camera
         var projMatrix = mat4.create();
         mat4.perspective(projMatrix, Math.PI / 2, gl.drawingBufferWidth / gl.drawingBufferHeight, 0.1, 10.0);
 
@@ -452,7 +492,25 @@
         var viewProjMatrix = mat4.create();
         mat4.multiply(viewProjMatrix, projMatrix, viewMatrix);
 
-        // var lightPosition = vec3.fromValues(1, 1, 0.5);
+
+        // top down assist camera
+        var projMatrixAssistCam = mat4.create();
+        mat4.perspective(projMatrixAssistCam, Math.PI / 2, gl.drawingBufferWidth / gl.drawingBufferHeight, 0.1, 10.0);
+
+        var viewMatrixAssistCam = mat4.create();
+        var eyePositionAssistCam = vec3.fromValues(0, 3, 0);
+        // var eyePositionAssistCam = vec3.fromValues(0, 0.8, 2);
+        mat4.lookAt(viewMatrixAssistCam, eyePositionAssistCam, vec3.fromValues(0, 0, 0), vec3.fromValues(0, 0, -1));
+        // mat4.lookAt(viewMatrixAssistCam, eyePositionAssistCam, vec3.fromValues(0, 0, 0), vec3.fromValues(0, 1, 0));
+
+        var viewProjMatrixAssistCam = mat4.create();
+        mat4.multiply(viewProjMatrixAssistCam, projMatrixAssistCam, viewMatrixAssistCam);
+
+
+        gl.useProgram(programAssistCam);
+        gl.uniformMatrix4fv(viewProjMatrixLocationAssistCam, false, viewProjMatrixAssistCam);
+        gl.useProgram(null);
+
         var lightPosition = vec3.fromValues(1, 1, 2);
 
         var modelMatrix = mat4.create();
@@ -468,8 +526,14 @@
         gl.bindBufferBase(gl.UNIFORM_BUFFER, 0, sceneUniformBuffer);
         gl.bufferData(gl.UNIFORM_BUFFER, sceneUniformData, gl.STATIC_DRAW);
 
-        var angleX = 0;
-        var angleY = 0;
+        var assistCamUniformData = new Float32Array(24);
+        assistCamUniformData.set(viewProjMatrixAssistCam);
+        assistCamUniformData.set(eyePositionAssistCam, 16);
+        assistCamUniformData.set(lightPosition, 20);
+
+        var assistCamUniformBuffer = gl.createBuffer();
+        gl.bindBufferBase(gl.UNIFORM_BUFFER, 1, assistCamUniformBuffer);
+        gl.bufferData(gl.UNIFORM_BUFFER, assistCamUniformData, gl.STATIC_DRAW);
 
         var image = new Image();
         var firstFrame = true;
@@ -492,9 +556,15 @@
 
             gl.useProgram(program);
             gl.uniform1i(texLocation, 0);
+            gl.useProgram(null);
+            
+            gl.blendEquation( gl.FUNC_ADD );
+            gl.blendFunc( gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA );
 
             var rotationMatrix = mat4.create();
             var node, bbox, isVisible = true;
+            var isDrawNodes = new Array(nodes.length);
+            var invisibleNodesCount = 0;
 
             function draw() {
                 // angleX += 0.01;
@@ -508,10 +578,17 @@
 
                 // gl.clear(gl.COLOR_BUFFER_BIT);
                 // gl.drawArrays(gl.TRIANGLES, 0, numVertices);
+                
+                invisibleNodesCount = 0;
 
+                gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
+                gl.clearColor(0, 0, 0, 1);
+                gl.enable(gl.DEPTH_TEST);
                 gl.colorMask(true, true, true, true);
                 gl.depthMask(true);
                 gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
+                gl.uniformBlockBinding(program, sceneUniformsLocation, 0);
 
                 for (var i = 0, len = nodes.length; i < len; ++i) {
                     node = nodes[i];
@@ -528,11 +605,15 @@
                     // use occlusion query with drawing bounding box
                     gl.colorMask(false, false, false, false);
                     gl.depthMask(false);
+                    
                     gl.useProgram(programBBox);
                     gl.bindVertexArray(node.vaobbox);
 
                     gl.uniformMatrix4fv(modelMatrixLocationBBox, false, node.modelMatrix);
                     
+                    isVisible = true;
+                    isDrawNodes[i] = true;
+
                     if (!firstFrame) {
                         if (gl.getQueryParameter(node.query, gl.QUERY_RESULT_AVAILABLE)) {
                             // A query's result is never available in the same frame
@@ -542,12 +623,14 @@
                             if (samplesPassed == 0) {
                                 // console.log('invisible node ' + i);
                                 isVisible = false;
+                                isDrawNodes[i] = false;
+                                invisibleNodesCount++;
                             }
-                            else
-                            {
-                                // console.log('!!!visible node ' + i);
-                                isVisible = true;
-                            }
+                            // else
+                            // {
+                            //     // console.log('!!!visible node ' + i);
+                            //     visibleNodesCount++;
+                            // }
                         }
                     }
                     
@@ -579,6 +662,43 @@
                 if (firstFrame) {
                     firstFrame = false;
                 }
+
+                // console.log('invisible node count: ' + invisibleNodesCount);
+
+
+                // draw assist camera view
+                gl.uniformBlockBinding(program, sceneUniformsLocation, 1);
+                
+                gl.viewport(assistCamViewport[0], assistCamViewport[1], assistCamViewport[2], assistCamViewport[3]);
+                gl.enable(gl.BLEND);
+                gl.enable(gl.SCISSOR_TEST);
+                gl.scissor(assistCamViewport[0], assistCamViewport[1], assistCamViewport[2], assistCamViewport[3]);
+                gl.colorMask(true, true, true, true);
+                gl.depthMask(true);
+                // gl.disable(gl.DEPTH_TEST);
+                // gl.clearColor(1, 1, 1, 1);
+                gl.clearColor(0.3, 0.3, 0.3, 1);
+                gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+                // gl.useProgram(programAssistCam);
+                gl.useProgram(program);
+                for (i = 0, len = nodes.length; i < len; ++i) {
+                    if (isDrawNodes[i]) {
+                        // console.log(i);
+                        node = nodes[i];
+                        gl.bindVertexArray(node.vao);
+                        // gl.uniformMatrix4fv(modelMatrixLocationAssistCam, false, node.modelMatrix);
+                        gl.uniformMatrix4fv(modelMatrixLocation, false, node.modelMatrix);
+                        if (node.indicesLength) {
+                            gl.drawElements(gl.TRIANGLES, node.indicesLength, gl.UNSIGNED_SHORT, 0);
+                        } else {
+                            gl.drawArrays(gl.TRIANGLES, 0, node.numVertices);
+                        }
+                    }
+                }
+                gl.disable(gl.SCISSOR_TEST);
+                gl.disable(gl.BLEND);
+
+
 
                 requestAnimationFrame(draw);
             }

--- a/occlusion.html
+++ b/occlusion.html
@@ -51,10 +51,13 @@
     </div>
     <canvas id="gl-canvas"></canvas>
     <div id="occlusion-controls">
+        Num of Nodes: <div style="display: inline-block" id="num-nodes"></div>
+        <br/>
+        Num of Invisible Nodes: <div style="display: inline-block" id="num-invisible-nodes"></div>
+        <br/>
         Enable Occlusion Culling: <input id="occlusion-toggle" type="checkbox" checked>
         <br/>
         Show top down assist camera: <input id="assist-cam-toggle" type="checkbox" checked> 
-        <!-- <br/> -->
     </div>
     <script type="x-shader/vs" id="vertex-draw">
         #version 300 es
@@ -433,8 +436,8 @@
 
 
         // var NUM_NODES = 32;
-        var NUM_NODES = 128;
-        // var NUM_NODES = 320;
+        // var NUM_NODES = 128;
+        var NUM_NODES = 320;
         var NUM_PER_ROW = 8;
         var RADIUS = 0.6;
         var nodes = new Array(NUM_NODES);
@@ -504,6 +507,8 @@
             }
             return - a.translate.y + b.translate.y;
         });
+
+        document.getElementById("num-nodes").innerHTML = nodes.length;
 
         //////////////////////////
         // UNIFORM DATA
@@ -717,6 +722,7 @@
                 }
 
                 // console.log('invisible node count: ' + invisibleNodesCount);
+                document.getElementById("num-invisible-nodes").innerHTML = invisibleNodesCount;
 
 
                 // draw assist camera view

--- a/occlusion.html
+++ b/occlusion.html
@@ -150,8 +150,8 @@
         layout(std140, column_major) uniform;
         
         layout(location=0) in vec4 position;
-        layout(location=1) in vec2 uv;
-        layout(location=2) in vec4 normal;
+        //layout(location=1) in vec2 uv;
+        //layout(location=2) in vec4 normal;
         
         uniform mat4 uViewProj;
         
@@ -498,7 +498,7 @@
         mat4.perspective(projMatrixAssistCam, Math.PI / 2, gl.drawingBufferWidth / gl.drawingBufferHeight, 0.1, 10.0);
 
         var viewMatrixAssistCam = mat4.create();
-        var eyePositionAssistCam = vec3.fromValues(0, 3, 0);
+        var eyePositionAssistCam = vec3.fromValues(0, 2, 0);
         // var eyePositionAssistCam = vec3.fromValues(0, 0.8, 2);
         mat4.lookAt(viewMatrixAssistCam, eyePositionAssistCam, vec3.fromValues(0, 0, 0), vec3.fromValues(0, 0, -1));
         // mat4.lookAt(viewMatrixAssistCam, eyePositionAssistCam, vec3.fromValues(0, 0, 0), vec3.fromValues(0, 1, 0));
@@ -675,19 +675,19 @@
                 gl.scissor(assistCamViewport[0], assistCamViewport[1], assistCamViewport[2], assistCamViewport[3]);
                 gl.colorMask(true, true, true, true);
                 gl.depthMask(true);
-                // gl.disable(gl.DEPTH_TEST);
+                gl.disable(gl.DEPTH_TEST);
                 // gl.clearColor(1, 1, 1, 1);
                 gl.clearColor(0.3, 0.3, 0.3, 1);
                 gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-                // gl.useProgram(programAssistCam);
-                gl.useProgram(program);
+                gl.useProgram(programAssistCam);
+                // gl.useProgram(program);
                 for (i = 0, len = nodes.length; i < len; ++i) {
                     if (isDrawNodes[i]) {
                         // console.log(i);
                         node = nodes[i];
                         gl.bindVertexArray(node.vao);
-                        // gl.uniformMatrix4fv(modelMatrixLocationAssistCam, false, node.modelMatrix);
-                        gl.uniformMatrix4fv(modelMatrixLocation, false, node.modelMatrix);
+                        gl.uniformMatrix4fv(modelMatrixLocationAssistCam, false, node.modelMatrix);
+                        // gl.uniformMatrix4fv(modelMatrixLocation, false, node.modelMatrix);
                         if (node.indicesLength) {
                             gl.drawElements(gl.TRIANGLES, node.indicesLength, gl.UNSIGNED_SHORT, 0);
                         } else {

--- a/occlusion.html
+++ b/occlusion.html
@@ -330,8 +330,8 @@
         // sphere high poly
 
         var sphereHigh = utils.createSphere({
-            long_bands: 96,
-            lat_bands: 96,
+            long_bands: 128,
+            lat_bands: 128,
             radius: 0.6
         });
 
@@ -382,8 +382,8 @@
         // sphere low poly
 
         var sphere = utils.createSphere({
-            long_bands: 16,
-            lat_bands: 16,
+            long_bands: 96,
+            lat_bands: 96,
             radius: 0.5
         });
 
@@ -433,7 +433,8 @@
 
 
         // var NUM_NODES = 32;
-        var NUM_NODES = 256;
+        var NUM_NODES = 128;
+        // var NUM_NODES = 320;
         var NUM_PER_ROW = 8;
         var RADIUS = 0.6;
         var nodes = new Array(NUM_NODES);
@@ -501,7 +502,7 @@
             if (x !== 0) {
                 return x;
             }
-            return a.translate.y - b.translate.y;
+            return - a.translate.y + b.translate.y;
         });
 
         //////////////////////////
@@ -526,9 +527,9 @@
         mat4.perspective(projMatrixAssistCam, Math.PI / 2, gl.drawingBufferWidth / gl.drawingBufferHeight, 0.1, 10.0);
 
         var viewMatrixAssistCam = mat4.create();
-        var eyePositionAssistCam = vec3.fromValues(0, 4, 0);
+        var eyePositionAssistCam = vec3.fromValues(3, 5, -2);
         // var eyePositionAssistCam = vec3.fromValues(0, 0.8, 2);
-        mat4.lookAt(viewMatrixAssistCam, eyePositionAssistCam, vec3.fromValues(0, 0, 0), vec3.fromValues(0, 0, -1));
+        mat4.lookAt(viewMatrixAssistCam, eyePositionAssistCam, vec3.fromValues(3, 0, -2), vec3.fromValues(0, 0, -1));
         // mat4.lookAt(viewMatrixAssistCam, eyePositionAssistCam, vec3.fromValues(0, 0, 0), vec3.fromValues(0, 1, 0));
 
         var viewProjMatrixAssistCam = mat4.create();
@@ -593,6 +594,7 @@
 
             var rotationMatrix = mat4.create();
             var node, bbox, isVisible = true;
+            var doquery = true;
 
             for (var i = 0, len = isDrawNodes.length; i < len; ++i) {
                 isDrawNodes[i] = true;
@@ -648,6 +650,7 @@
                         
                         isVisible = true;
                         isDrawNodes[i] = true;
+                        doquery = true;
 
                         if (!firstFrame) {
                             if (gl.getQueryParameter(node.query, gl.QUERY_RESULT_AVAILABLE)) {
@@ -666,12 +669,21 @@
                                 //     // console.log('!!!visible node ' + i);
                                 //     visibleNodesCount++;
                                 // }
+                            } 
+                            else {
+                                isVisible = isDrawNodes[i];
+                                // isDrawNodes[i] = false;
+                                // invisibleNodesCount++;
+                                doquery = false;
                             }
                         }
                         
-                        gl.beginQuery(gl.ANY_SAMPLES_PASSED, node.query);
-                        gl.drawArrays(gl.TRIANGLES, 0, node.bboxNumVertices);
-                        gl.endQuery(gl.ANY_SAMPLES_PASSED);
+                        if (doquery) {
+                            gl.beginQuery(gl.ANY_SAMPLES_PASSED, node.query);
+                            gl.drawArrays(gl.TRIANGLES, 0, node.bboxNumVertices);
+                            gl.endQuery(gl.ANY_SAMPLES_PASSED);
+                        }
+                        
                     }
 
                     

--- a/occlusion.html
+++ b/occlusion.html
@@ -185,8 +185,8 @@
 
         document.getElementById("occlusion-toggle").addEventListener("change", function() {
             occlusionCullingEnabled = this.checked;
-            for(var i = 0, len = isDrawNodes.length; i < len; i++) {
-                isDrawNodes[i] = true;
+            for(var i = 0, len = nodes.length; i < len; i++) {
+                nodes[i].isDrawNode = true;
             }
         });
 
@@ -397,7 +397,8 @@
                 vaobbox: sphereBBoxArray,
                 bboxNumVertices: sphere.bbox.bbox.positions.length / 3,
 
-                query: gl.createQuery()
+                query: gl.createQuery(),
+                isDrawNode: true
             };
             
             utils.xformMatrix(nodes[i].modelMatrix, nodes[i].translate, null, nodes[i].scale);
@@ -424,11 +425,11 @@
         var tmpVec4a = vec4.create();
         var tmpVec4b = vec4.create();
         var tmpMat4 = mat4.create();
-        nodes.sort(function(a, b){
+        function sortNodes(a, b) {
             // sort nodes by dist to eye (via pos in view space)
             // we assume their relative order is static in this demo
-            vec4.set(tmpVec4a, a.translate.x, a.translate.y, a.translate.z, 1.0);
-            vec4.set(tmpVec4b, b.translate.x, b.translate.y, b.translate.z, 1.0);
+            vec4.set(tmpVec4a, a.translate[0], a.translate[1], a.translate[2], 1.0);
+            vec4.set(tmpVec4b, b.translate[0], b.translate[1], b.translate[2], 1.0);
 
             mat4.mul(tmpMat4, viewMatrix, a.modelMatrix);
             vec4.transformMat4(tmpVec4a, tmpVec4a, tmpMat4);
@@ -436,14 +437,8 @@
             vec4.transformMat4(tmpVec4b, tmpVec4b, tmpMat4);
             
             vec4.sub(tmpVec4a, tmpVec4a, tmpVec4b);
-            if (tmpVec4a[2] !== 0) {
-                return tmpVec4a[2];
-            }
-            if (tmpVec4a[0] !== 0) {
-                return tmpVec4a[0];
-            }
-            return -tmpVec4a[1];
-        });
+            return -tmpVec4a[2];
+        }
 
         // top down assist camera
         var projMatrixAssistCam = mat4.create();
@@ -486,10 +481,6 @@
 
         var image = new Image();
         var firstFrame = true;
-        var isDrawNodes = new Array(nodes.length);
-        for (var i = 0, len = isDrawNodes.length; i < len; ++i) {
-            isDrawNodes[i] = true;
-        }
         var invisibleNodesCount = 0;
 
         image.onload = function() {
@@ -520,11 +511,28 @@
             var doquery = true;
             var samplesPassed;
             
+            var i, len = nodes.length;
 
             var t = 0;
             function draw() {
                 t += 0.01;
                 invisibleNodesCount = 0;
+
+                // transform nodes
+                for (i = 0; i < len; ++i) {
+                    node = nodes[i];
+
+                    node.rotate[1] = Math.PI / 6 * (Math.sin(t - Math.PI / 2) + 1);
+
+                    utils.xformMatrix(node.modelMatrix, node.translate, null, node.scale);
+                    mat4.fromYRotation(rotationMatrix, node.rotate[1]);
+                    mat4.multiply(node.modelMatrix, rotationMatrix, node.modelMatrix);
+                }
+
+                if (occlusionCullingEnabled) {
+                    // sort by view distance
+                    nodes.sort(sortNodes);
+                }
 
                 gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
                 gl.clearColor(0, 0, 0, 1);
@@ -533,15 +541,9 @@
                 gl.depthMask(true);
                 gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
-                for (var i = 0, len = nodes.length; i < len; ++i) {
+                for (i = 0; i < len; ++i) {
                     node = nodes[i];
                     bbox = node.bbox;
-
-                    node.rotate[1] = Math.PI / 6 * (Math.sin(t - Math.PI / 2) + 1);
-
-                    utils.xformMatrix(node.modelMatrix, node.translate, null, node.scale);
-                    mat4.fromYRotation(rotationMatrix, node.rotate[1]);
-                    mat4.multiply(node.modelMatrix, rotationMatrix, node.modelMatrix);
                     
                     if (occlusionCullingEnabled) {
                         // use occlusion query with drawing bounding box
@@ -565,17 +567,17 @@
                                 if (samplesPassed == 0) {
                                     // console.log('invisible node ' + i);
                                     isVisible = false;
-                                    isDrawNodes[i] = false;
+                                    node.isDrawNode = false;
                                 }
                                 else {
                                     isVisible = true;
-                                    isDrawNodes[i] = true;
+                                    node.isDrawNode = true;
                                 }
                             } 
                             else {
                                 // query is not ready, use visible info from previous frame (to make assist cam looks correct)
                                 // if we want to be conservative, simple set isVisible to true
-                                isVisible = isDrawNodes[i];
+                                isVisible = node.isDrawNode;
                                 doquery = false;
                             }
                         }
@@ -629,9 +631,9 @@
                     gl.clearColor(0.3, 0.3, 0.3, 1);
                     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
                     gl.useProgram(programAssistCam);
-                    for (i = 0, len = nodes.length; i < len; ++i) {
-                        if (isDrawNodes[i]) {
-                            node = nodes[i];
+                    for (i = 0; i < len; ++i) {
+                        node = nodes[i];
+                        if (node.isDrawNode) {
                             gl.bindVertexArray(node.vao);
                             gl.uniformMatrix4fv(modelMatrixLocationAssistCam, false, node.modelMatrix);
                             gl.drawElements(gl.TRIANGLES, node.indicesLength, gl.UNSIGNED_SHORT, 0);

--- a/occlusion.html
+++ b/occlusion.html
@@ -176,36 +176,41 @@
         // SET UP GEOMETRY & scene
         /////////////////////
 
-        // var box = utils.createBox({dimensions: [1.0, 1.0, 1.0]});
+        var box = utils.createBox({dimensions: [1.0, 1.0, 1.0]});
         // var numVertices = box.positions.length / 3;
 
-        // var cubeArray = gl.createVertexArray();
-        // gl.bindVertexArray(cubeArray);
+        var cubeArray = gl.createVertexArray();
+        gl.bindVertexArray(cubeArray);
 
-        // var positionBuffer = gl.createBuffer();
-        // gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
-        // gl.bufferData(gl.ARRAY_BUFFER, box.positions, gl.STATIC_DRAW);
-        // gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
-        // gl.enableVertexAttribArray(0);
+        var positionBuffer = gl.createBuffer();
+        gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+        gl.bufferData(gl.ARRAY_BUFFER, box.positions, gl.STATIC_DRAW);
+        gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
+        gl.enableVertexAttribArray(0);
 
-        // var uvBuffer = gl.createBuffer();
-        // gl.bindBuffer(gl.ARRAY_BUFFER, uvBuffer);
-        // gl.bufferData(gl.ARRAY_BUFFER, box.uvs, gl.STATIC_DRAW);
-        // gl.vertexAttribPointer(1, 2, gl.FLOAT, false, 0, 0);
-        // gl.enableVertexAttribArray(1);
+        var uvBuffer = gl.createBuffer();
+        gl.bindBuffer(gl.ARRAY_BUFFER, uvBuffer);
+        gl.bufferData(gl.ARRAY_BUFFER, box.uvs, gl.STATIC_DRAW);
+        gl.vertexAttribPointer(1, 2, gl.FLOAT, false, 0, 0);
+        gl.enableVertexAttribArray(1);
 
-        // var normalBuffer = gl.createBuffer();
-        // gl.bindBuffer(gl.ARRAY_BUFFER, normalBuffer);
-        // gl.bufferData(gl.ARRAY_BUFFER, box.normals, gl.STATIC_DRAW);
-        // gl.vertexAttribPointer(2, 3, gl.FLOAT, false, 0, 0);
-        // gl.enableVertexAttribArray(2);
+        var normalBuffer = gl.createBuffer();
+        gl.bindBuffer(gl.ARRAY_BUFFER, normalBuffer);
+        gl.bufferData(gl.ARRAY_BUFFER, box.normals, gl.STATIC_DRAW);
+        gl.vertexAttribPointer(2, 3, gl.FLOAT, false, 0, 0);
+        gl.enableVertexAttribArray(2);
+
+        gl.bindVertexArray(null);
+
 
         var sphere = utils.createSphere({
             long_bands: 16,
             lat_bands: 16,
             radius: 0.5
         });
-        var numVertices = sphere.positions.length / 3;
+
+        sphere.bbox = utils.computeBoundingBox(sphere.positions, {geo: true});
+        // var numVertices = sphere.positions.length / 3;
 
         var sphereArray = gl.createVertexArray();
         gl.bindVertexArray(sphereArray);
@@ -234,25 +239,41 @@
 
         gl.bindVertexArray(null);
 
-        var NUM_SPHERES = 32;
+        var NUM_NODES = 32;
         var NUM_PER_ROW = 8;
         var RADIUS = 0.6;
-        var nodes = new Array(NUM_SPHERES);
+        var nodes = new Array(NUM_NODES);
 
-        for (var i = 0; i < NUM_SPHERES; ++i) {
+        for (var i = 0; i < NUM_NODES; ++i) {
             var angle = 2 * Math.PI * (i % NUM_PER_ROW) / NUM_PER_ROW;
             var x = Math.sin(angle) * RADIUS;
             var y = Math.floor(i / NUM_PER_ROW) / (NUM_PER_ROW / 4) - 0.75;
             var z = Math.cos(angle) * RADIUS;
-            nodes[i] = {
-                scale: [0.8, 0.8, 0.8],
-                rotate: [0, 0, 0], // Will be used for global rotation
-                translate: [x, y, z],
-                modelMatrix: mat4.create(),
 
-                vao: sphereArray,
-                indicesLength: sphere.indices.length
-            };
+            if (i % 2 == 0) {
+                // sphere
+                nodes[i] = {
+                    scale: [0.8, 0.8, 0.8],
+                    rotate: [0, 0, 0], // Will be used for global rotation
+                    translate: [x, y, z],
+                    modelMatrix: mat4.create(),
+
+                    vao: sphereArray,
+                    indicesLength: sphere.indices.length
+                };
+            } else {
+                // cube
+                nodes[i] = {
+                    scale: [0.4, 0.4, 0.4],
+                    rotate: [0, 0, 0], // Will be used for global rotation
+                    translate: [x, y, z],
+                    modelMatrix: mat4.create(),
+
+                    vao: cubeArray,
+                    numVertices: box.positions.length / 3
+                }
+            }
+            
         }
 
         //////////////////////////
@@ -340,7 +361,12 @@
                     gl.uniformMatrix4fv(modelMatrixLocation, false, node.modelMatrix);
                     // modelMatrixData.set(node.modelMatrix, i * 16);
 
-                    gl.drawElements(gl.TRIANGLES, node.indicesLength, gl.UNSIGNED_SHORT, 0);
+                    if (node.indicesLength) {
+                        gl.drawElements(gl.TRIANGLES, node.indicesLength, gl.UNSIGNED_SHORT, 0);
+                    } else {
+                        gl.drawArrays(gl.TRIANGLES, 0, node.numVertices);
+                    }
+                    
                 }
                 
 

--- a/occlusion.html
+++ b/occlusion.html
@@ -432,16 +432,17 @@
         gl.bindVertexArray(null);
 
 
-        var NUM_NODES = 32;
+        // var NUM_NODES = 32;
+        var NUM_NODES = 256;
         var NUM_PER_ROW = 8;
         var RADIUS = 0.6;
         var nodes = new Array(NUM_NODES);
 
         for (var i = 0; i < NUM_NODES; ++i) {
             var angle = 2 * Math.PI * (i % NUM_PER_ROW) / NUM_PER_ROW;
-            var x = Math.sin(angle) * RADIUS;
-            var y = Math.floor(i / NUM_PER_ROW) / (NUM_PER_ROW / 4) - 0.75;
-            var z = Math.cos(angle) * RADIUS;
+            var x = Math.sin(angle) * RADIUS + 2 * Math.floor(i / 64) - 0.5;
+            var y = (Math.floor(i / NUM_PER_ROW) % 4) / (NUM_PER_ROW / 4) - 0.75;
+            var z = Math.cos(angle) * RADIUS - 2 * Math.floor(i / 32 % 2);
 
             if (i % 2 == 0) {
                 // sphere low
@@ -525,7 +526,7 @@
         mat4.perspective(projMatrixAssistCam, Math.PI / 2, gl.drawingBufferWidth / gl.drawingBufferHeight, 0.1, 10.0);
 
         var viewMatrixAssistCam = mat4.create();
-        var eyePositionAssistCam = vec3.fromValues(0, 2, 0);
+        var eyePositionAssistCam = vec3.fromValues(0, 4, 0);
         // var eyePositionAssistCam = vec3.fromValues(0, 0.8, 2);
         mat4.lookAt(viewMatrixAssistCam, eyePositionAssistCam, vec3.fromValues(0, 0, 0), vec3.fromValues(0, 0, -1));
         // mat4.lookAt(viewMatrixAssistCam, eyePositionAssistCam, vec3.fromValues(0, 0, 0), vec3.fromValues(0, 1, 0));
@@ -696,7 +697,7 @@
 
 
                 
-                if (firstFrame) {
+                if (firstFrame && occlusionCullingEnabled) {
                     firstFrame = false;
                 }
                 else if (!occlusionCullingEnabled) {

--- a/occlusion.html
+++ b/occlusion.html
@@ -31,7 +31,7 @@
     <script src="utils/utils.js"></script>
     <link rel="stylesheet" href="css/webgl2examples.css">
     <style>
-        #ssao-controls {
+        #occlusion-controls {
             position: absolute;
             bottom: 20px;
             right: 20px;
@@ -50,8 +50,11 @@
         </div>
     </div>
     <canvas id="gl-canvas"></canvas>
-    <div id="ssao-controls">
-        Enable Occlusion Culling: <input id="ssao-toggle" type="checkbox" checked>
+    <div id="occlusion-controls">
+        Enable Occlusion Culling: <input id="occlusion-toggle" type="checkbox" checked>
+        <br/>
+        Show top down assist camera: <input id="assist-cam-toggle" type="checkbox" checked> 
+        <!-- <br/> -->
     </div>
     <script type="x-shader/vs" id="vertex-draw">
         #version 300 es
@@ -174,6 +177,20 @@
         }
     </script>
     <script type="text/javascript">
+        var occlusionCullingEnabled = true;
+        var showAssistCamEnabled = true;
+
+        document.getElementById("occlusion-toggle").addEventListener("change", function() {
+            occlusionCullingEnabled = this.checked;
+            for(var i = 0, len = isDrawNodes.length; i < len; i++) {
+                isDrawNodes[i] = true;
+            }
+        });
+
+        document.getElementById("assist-cam-toggle").addEventListener("change", function() {
+            showAssistCamEnabled = this.checked;
+        });
+
         var canvas = document.getElementById("gl-canvas");
         canvas.width = window.innerWidth;
         canvas.height = window.innerHeight;
@@ -537,6 +554,8 @@
 
         var image = new Image();
         var firstFrame = true;
+        var isDrawNodes = new Array(nodes.length);
+        var invisibleNodesCount = 0;
 
         image.onload = function() {
             var texture = gl.createTexture();
@@ -563,8 +582,10 @@
 
             var rotationMatrix = mat4.create();
             var node, bbox, isVisible = true;
-            var isDrawNodes = new Array(nodes.length);
-            var invisibleNodesCount = 0;
+
+            for (var i = 0, len = isDrawNodes.length; i < len; ++i) {
+                isDrawNodes[i] = true;
+            }
 
             function draw() {
                 // angleX += 0.01;
@@ -588,7 +609,8 @@
                 gl.depthMask(true);
                 gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
-                gl.uniformBlockBinding(program, sceneUniformsLocation, 0);
+                // gl.uniformBlockBinding(program, sceneUniformsLocation, 0);
+
 
                 for (var i = 0, len = nodes.length; i < len; ++i) {
                     node = nodes[i];
@@ -601,53 +623,52 @@
                     mat4.multiply(node.modelMatrix, rotationMatrix, node.modelMatrix);
 
                     
+                    if (occlusionCullingEnabled) {
+                        // use occlusion query with drawing bounding box
+                        gl.colorMask(false, false, false, false);
+                        gl.depthMask(false);
+                        
+                        gl.useProgram(programBBox);
+                        gl.bindVertexArray(node.vaobbox);
 
-                    // use occlusion query with drawing bounding box
-                    gl.colorMask(false, false, false, false);
-                    gl.depthMask(false);
-                    
-                    gl.useProgram(programBBox);
-                    gl.bindVertexArray(node.vaobbox);
+                        gl.uniformMatrix4fv(modelMatrixLocationBBox, false, node.modelMatrix);
+                        
+                        isVisible = true;
+                        isDrawNodes[i] = true;
 
-                    gl.uniformMatrix4fv(modelMatrixLocationBBox, false, node.modelMatrix);
-                    
-                    isVisible = true;
-                    isDrawNodes[i] = true;
+                        if (!firstFrame) {
+                            if (gl.getQueryParameter(node.query, gl.QUERY_RESULT_AVAILABLE)) {
+                                // A query's result is never available in the same frame
+                                // the query was issued.  Try in the next frame.
+                                var samplesPassed = gl.getQueryParameter(node.query, gl.QUERY_RESULT);
 
-                    if (!firstFrame) {
-                        if (gl.getQueryParameter(node.query, gl.QUERY_RESULT_AVAILABLE)) {
-                            // A query's result is never available in the same frame
-                            // the query was issued.  Try in the next frame.
-                            var samplesPassed = gl.getQueryParameter(node.query, gl.QUERY_RESULT);
-
-                            if (samplesPassed == 0) {
-                                // console.log('invisible node ' + i);
-                                isVisible = false;
-                                isDrawNodes[i] = false;
-                                invisibleNodesCount++;
+                                if (samplesPassed == 0) {
+                                    // console.log('invisible node ' + i);
+                                    isVisible = false;
+                                    isDrawNodes[i] = false;
+                                    invisibleNodesCount++;
+                                }
+                                // else
+                                // {
+                                //     // console.log('!!!visible node ' + i);
+                                //     visibleNodesCount++;
+                                // }
                             }
-                            // else
-                            // {
-                            //     // console.log('!!!visible node ' + i);
-                            //     visibleNodesCount++;
-                            // }
                         }
+                        
+                        gl.beginQuery(gl.ANY_SAMPLES_PASSED, node.query);
+                        gl.drawArrays(gl.TRIANGLES, 0, node.bboxNumVertices);
+                        gl.endQuery(gl.ANY_SAMPLES_PASSED);
                     }
-                    
-
-                    gl.beginQuery(gl.ANY_SAMPLES_PASSED, node.query);
-                    gl.drawArrays(gl.TRIANGLES, 0, node.bboxNumVertices);
-                    gl.endQuery(gl.ANY_SAMPLES_PASSED);
 
                     
-                    if (isVisible) {
+                    if (!occlusionCullingEnabled || isVisible) {
                         gl.colorMask(true, true, true, true);
                         gl.depthMask(true);
                         gl.useProgram(program);
                         gl.bindVertexArray(node.vao);
 
                         gl.uniformMatrix4fv(modelMatrixLocation, false, node.modelMatrix);
-                        // modelMatrixData.set(node.modelMatrix, i * 16);
 
                         if (node.indicesLength) {
                             gl.drawElements(gl.TRIANGLES, node.indicesLength, gl.UNSIGNED_SHORT, 0);
@@ -658,45 +679,55 @@
                     
                     
                 }
+
+
+
+
                 
                 if (firstFrame) {
                     firstFrame = false;
+                }
+                else if (!occlusionCullingEnabled) {
+                    firstFrame = true;
                 }
 
                 // console.log('invisible node count: ' + invisibleNodesCount);
 
 
                 // draw assist camera view
-                gl.uniformBlockBinding(program, sceneUniformsLocation, 1);
+                if (showAssistCamEnabled) {
+                    // gl.uniformBlockBinding(program, sceneUniformsLocation, 1);
                 
-                gl.viewport(assistCamViewport[0], assistCamViewport[1], assistCamViewport[2], assistCamViewport[3]);
-                gl.enable(gl.BLEND);
-                gl.enable(gl.SCISSOR_TEST);
-                gl.scissor(assistCamViewport[0], assistCamViewport[1], assistCamViewport[2], assistCamViewport[3]);
-                gl.colorMask(true, true, true, true);
-                gl.depthMask(true);
-                gl.disable(gl.DEPTH_TEST);
-                // gl.clearColor(1, 1, 1, 1);
-                gl.clearColor(0.3, 0.3, 0.3, 1);
-                gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-                gl.useProgram(programAssistCam);
-                // gl.useProgram(program);
-                for (i = 0, len = nodes.length; i < len; ++i) {
-                    if (isDrawNodes[i]) {
-                        // console.log(i);
-                        node = nodes[i];
-                        gl.bindVertexArray(node.vao);
-                        gl.uniformMatrix4fv(modelMatrixLocationAssistCam, false, node.modelMatrix);
-                        // gl.uniformMatrix4fv(modelMatrixLocation, false, node.modelMatrix);
-                        if (node.indicesLength) {
-                            gl.drawElements(gl.TRIANGLES, node.indicesLength, gl.UNSIGNED_SHORT, 0);
-                        } else {
-                            gl.drawArrays(gl.TRIANGLES, 0, node.numVertices);
+                    gl.viewport(assistCamViewport[0], assistCamViewport[1], assistCamViewport[2], assistCamViewport[3]);
+                    gl.enable(gl.BLEND);
+                    gl.enable(gl.SCISSOR_TEST);
+                    gl.scissor(assistCamViewport[0], assistCamViewport[1], assistCamViewport[2], assistCamViewport[3]);
+                    gl.colorMask(true, true, true, true);
+                    gl.depthMask(true);
+                    gl.disable(gl.DEPTH_TEST);
+                    // gl.clearColor(1, 1, 1, 1);
+                    gl.clearColor(0.3, 0.3, 0.3, 1);
+                    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+                    gl.useProgram(programAssistCam);
+                    // gl.useProgram(program);
+                    for (i = 0, len = nodes.length; i < len; ++i) {
+                        if (isDrawNodes[i]) {
+                            // console.log(i);
+                            node = nodes[i];
+                            gl.bindVertexArray(node.vao);
+                            gl.uniformMatrix4fv(modelMatrixLocationAssistCam, false, node.modelMatrix);
+                            // gl.uniformMatrix4fv(modelMatrixLocation, false, node.modelMatrix);
+                            if (node.indicesLength) {
+                                gl.drawElements(gl.TRIANGLES, node.indicesLength, gl.UNSIGNED_SHORT, 0);
+                            } else {
+                                gl.drawArrays(gl.TRIANGLES, 0, node.numVertices);
+                            }
                         }
                     }
+                    gl.disable(gl.SCISSOR_TEST);
+                    gl.disable(gl.BLEND);
                 }
-                gl.disable(gl.SCISSOR_TEST);
-                gl.disable(gl.BLEND);
+               
 
 
 

--- a/occlusion.html
+++ b/occlusion.html
@@ -248,8 +248,6 @@
             console.error(gl.getProgramInfoLog(program));
         }
 
-
-
         var vsSourceBBox =  document.getElementById("vertex-bbox").text.trim();
         var fsSourceBBox =  document.getElementById("fragment-bbox").text.trim();
 
@@ -366,7 +364,6 @@
         gl.bindVertexArray(null);
 
 
-
         sphereHigh.bbox = utils.computeBoundingBox(sphereHigh.positions, {geo: true});
 
         var sphereHighBBoxArray = gl.createVertexArray();
@@ -380,8 +377,6 @@
 
         gl.bindVertexArray(null);
 
-
-
         // sphere low poly
 
         var sphere = utils.createSphere({
@@ -389,8 +384,6 @@
             lat_bands: 96,
             radius: 0.5
         });
-
-        // var numVertices = sphere.positions.length / 3;
 
         var sphereArray = gl.createVertexArray();
         gl.bindVertexArray(sphereArray);
@@ -419,8 +412,6 @@
 
         gl.bindVertexArray(null);
 
-
-
         sphere.bbox = utils.computeBoundingBox(sphere.positions, {geo: true});
 
         var sphereBBoxArray = gl.createVertexArray();
@@ -436,17 +427,21 @@
 
 
         // var NUM_NODES = 32;
+        // var NUM_NODES = 64;
         // var NUM_NODES = 128;
         var NUM_NODES = 320;
+        // var NUM_NODES = 512;
         var NUM_PER_ROW = 8;
         var RADIUS = 0.6;
         var nodes = new Array(NUM_NODES);
 
         for (var i = 0; i < NUM_NODES; ++i) {
             var angle = 2 * Math.PI * (i % NUM_PER_ROW) / NUM_PER_ROW;
-            var x = Math.sin(angle) * RADIUS + 2 * Math.floor(i / 64) - 0.5;
+            // var x = Math.sin(angle) * RADIUS + 2 * Math.floor(i / 64) - 0.5;
+            var x = Math.sin(angle) * RADIUS + 2 * Math.floor(i / 128) - 0.5;
             var y = (Math.floor(i / NUM_PER_ROW) % 4) / (NUM_PER_ROW / 4) - 0.75;
-            var z = Math.cos(angle) * RADIUS - 2 * Math.floor(i / 32 % 2);
+            // var z = Math.cos(angle) * RADIUS - 2 * Math.floor(i / 32 % 2);
+            var z = Math.cos(angle) * RADIUS - 2 * Math.floor(i / 32 % 4);
 
             if (i % 2 == 0) {
                 // sphere low
@@ -464,17 +459,6 @@
                     bboxNumVertices: sphere.bbox.bbox.positions.length / 3
                 };
             } else {
-                // // cube
-                // nodes[i] = {
-                //     scale: [0.4, 0.4, 0.4],
-                //     rotate: [0, 0, 0], // Will be used for global rotation
-                //     translate: [x, y, z],
-                //     modelMatrix: mat4.create(),
-
-                //     vao: cubeArray,
-                //     numVertices: box.positions.length / 3
-                // }
-
                 // sphere high
                 nodes[i] = {
                     scale: [0.8, 0.8, 0.8],
@@ -607,17 +591,6 @@
 
             var t = 0;
             function draw() {
-                // angleX += 0.01;
-                // angleY += 0.02;
-
-                // mat4.fromXRotation(rotateXMatrix, angleX);
-                // mat4.fromYRotation(rotateYMatrix, angleY);
-                // mat4.multiply(modelMatrix, rotateXMatrix, rotateYMatrix);
-
-                // gl.uniformMatrix4fv(modelMatrixLocation, false, modelMatrix);
-
-                // gl.clear(gl.COLOR_BUFFER_BIT);
-                // gl.drawArrays(gl.TRIANGLES, 0, numVertices);
                 t += 0.01;
                 invisibleNodesCount = 0;
 
@@ -627,9 +600,6 @@
                 gl.colorMask(true, true, true, true);
                 gl.depthMask(true);
                 gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-
-                // gl.uniformBlockBinding(program, sceneUniformsLocation, 0);
-
 
                 for (var i = 0, len = nodes.length; i < len; ++i) {
                     node = nodes[i];
@@ -677,16 +647,14 @@
                             } 
                             else {
                                 isVisible = isDrawNodes[i];
-                                // isDrawNodes[i] = false;
-                                // invisibleNodesCount++;
                                 doquery = false;
                             }
                         }
                         
                         if (doquery) {
-                            gl.beginQuery(gl.ANY_SAMPLES_PASSED, node.query);
+                            gl.beginQuery(gl.ANY_SAMPLES_PASSED_CONSERVATIVE, node.query);
                             gl.drawArrays(gl.TRIANGLES, 0, node.bboxNumVertices);
-                            gl.endQuery(gl.ANY_SAMPLES_PASSED);
+                            gl.endQuery(gl.ANY_SAMPLES_PASSED_CONSERVATIVE);
                         }
                         
                     }
@@ -710,8 +678,10 @@
                     
                 }
 
-
-
+                document.getElementById("num-invisible-nodes").innerHTML = invisibleNodesCount;
+                if (invisibleNodesCount < nodes.length / 2) {
+                    invisibleNodesCount += 0;
+                }
 
                 
                 if (firstFrame && occlusionCullingEnabled) {
@@ -721,14 +691,9 @@
                     firstFrame = true;
                 }
 
-                // console.log('invisible node count: ' + invisibleNodesCount);
-                document.getElementById("num-invisible-nodes").innerHTML = invisibleNodesCount;
-
 
                 // draw assist camera view
                 if (showAssistCamEnabled) {
-                    // gl.uniformBlockBinding(program, sceneUniformsLocation, 1);
-                
                     gl.viewport(assistCamViewport[0], assistCamViewport[1], assistCamViewport[2], assistCamViewport[3]);
                     gl.enable(gl.BLEND);
                     gl.enable(gl.SCISSOR_TEST);
@@ -743,11 +708,9 @@
                     // gl.useProgram(program);
                     for (i = 0, len = nodes.length; i < len; ++i) {
                         if (isDrawNodes[i]) {
-                            // console.log(i);
                             node = nodes[i];
                             gl.bindVertexArray(node.vao);
                             gl.uniformMatrix4fv(modelMatrixLocationAssistCam, false, node.modelMatrix);
-                            // gl.uniformMatrix4fv(modelMatrixLocation, false, node.modelMatrix);
                             if (node.indicesLength) {
                                 gl.drawElements(gl.TRIANGLES, node.indicesLength, gl.UNSIGNED_SHORT, 0);
                             } else {
@@ -758,9 +721,6 @@
                     gl.disable(gl.SCISSOR_TEST);
                     gl.disable(gl.BLEND);
                 }
-               
-
-
 
                 requestAnimationFrame(draw);
             }

--- a/occlusion.html
+++ b/occlusion.html
@@ -21,9 +21,6 @@
   IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
-<!-- 
-    SSAO algorithm from http://www.nutty.ca/?page_id=352&link=ssao
- -->
 <html>
 <head>
     <title>WebGL 2 Example: Occlusion culling using occlusion query</title>
@@ -156,8 +153,6 @@
         layout(std140, column_major) uniform;
         
         layout(location=0) in vec4 position;
-        //layout(location=1) in vec2 uv;
-        //layout(location=2) in vec4 normal;
         
         uniform mat4 uViewProj;
         
@@ -210,7 +205,6 @@
             gl.drawingBufferWidth / 5, 
             gl.drawingBufferHeight / 5
         ];
-
 
         gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
         gl.clearColor(0.0, 0.0, 0.0, 1.0)
@@ -363,7 +357,6 @@
 
         gl.bindVertexArray(null);
 
-
         sphereHigh.bbox = utils.computeBoundingBox(sphereHigh.positions, {geo: true});
 
         var sphereHighBBoxArray = gl.createVertexArray();
@@ -380,8 +373,8 @@
         // sphere low poly
 
         var sphere = utils.createSphere({
-            long_bands: 96,
-            lat_bands: 96,
+            long_bands: 64,
+            lat_bands: 64,
             radius: 0.5
         });
 
@@ -432,10 +425,8 @@
 
         for (var i = 0; i < NUM_NODES; ++i) {
             var angle = 2 * Math.PI * (i % NUM_PER_ROW) / NUM_PER_ROW;
-            // var x = Math.sin(angle) * RADIUS + 2 * Math.floor(i / 64) - 0.5;
             var x = Math.sin(angle) * RADIUS + 2 * Math.floor(i / 128) - 0.5;
             var y = (Math.floor(i / NUM_PER_ROW) % 4) / (NUM_PER_ROW / 4) - 0.75;
-            // var z = Math.cos(angle) * RADIUS - 2 * Math.floor(i / 32 % 2);
             var z = Math.cos(angle) * RADIUS - 2 * Math.floor(i / 32 % 4);
 
             if (i % 2 == 0) {
@@ -506,20 +497,16 @@
         var viewProjMatrix = mat4.create();
         mat4.multiply(viewProjMatrix, projMatrix, viewMatrix);
 
-
         // top down assist camera
         var projMatrixAssistCam = mat4.create();
         mat4.perspective(projMatrixAssistCam, Math.PI / 2, gl.drawingBufferWidth / gl.drawingBufferHeight, 0.1, 10.0);
 
         var viewMatrixAssistCam = mat4.create();
         var eyePositionAssistCam = vec3.fromValues(3, 5, -2);
-        // var eyePositionAssistCam = vec3.fromValues(0, 0.8, 2);
         mat4.lookAt(viewMatrixAssistCam, eyePositionAssistCam, vec3.fromValues(3, 0, -2), vec3.fromValues(0, 0, -1));
-        // mat4.lookAt(viewMatrixAssistCam, eyePositionAssistCam, vec3.fromValues(0, 0, 0), vec3.fromValues(0, 1, 0));
 
         var viewProjMatrixAssistCam = mat4.create();
         mat4.multiply(viewProjMatrixAssistCam, projMatrixAssistCam, viewMatrixAssistCam);
-
 
         gl.useProgram(programAssistCam);
         gl.uniformMatrix4fv(viewProjMatrixLocationAssistCam, false, viewProjMatrixAssistCam);
@@ -602,16 +589,15 @@
                     node = nodes[i];
                     bbox = node.bbox;
 
-                    // node.rotate[1] += 0.01;
                     node.rotate[1] = Math.PI / 6 * (Math.sin(t - Math.PI / 2) + 1);
 
                     utils.xformMatrix(node.modelMatrix, node.translate, null, node.scale);
                     mat4.fromYRotation(rotationMatrix, node.rotate[1]);
                     mat4.multiply(node.modelMatrix, rotationMatrix, node.modelMatrix);
-
                     
                     if (occlusionCullingEnabled) {
                         // use occlusion query with drawing bounding box
+                        // to determine if a node is visible
                         gl.colorMask(false, false, false, false);
                         gl.depthMask(false);
                         
@@ -619,8 +605,7 @@
                         gl.bindVertexArray(node.vaobbox);
 
                         gl.uniformMatrix4fv(modelMatrixLocationBBox, false, node.modelMatrix);
-                        
-                        // isDrawNodes[i] = true;
+
                         doquery = true;
 
                         if (!firstFrame) {
@@ -670,15 +655,12 @@
 
                         gl.drawElements(gl.TRIANGLES, node.indicesLength, gl.UNSIGNED_SHORT, 0);
                     }
-                    
-                    
                 }
 
                 document.getElementById("num-invisible-nodes").innerHTML = invisibleNodesCount;
                 if (invisibleNodesCount < nodes.length / 2) {
                     invisibleNodesCount += 0;
                 }
-
                 
                 if (firstFrame && occlusionCullingEnabled) {
                     firstFrame = false;
@@ -686,7 +668,6 @@
                 else if (!occlusionCullingEnabled) {
                     firstFrame = true;
                 }
-
 
                 // draw assist camera view
                 if (showAssistCamEnabled) {
@@ -697,11 +678,9 @@
                     gl.colorMask(true, true, true, true);
                     gl.depthMask(true);
                     gl.disable(gl.DEPTH_TEST);
-                    // gl.clearColor(1, 1, 1, 1);
                     gl.clearColor(0.3, 0.3, 0.3, 1);
                     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
                     gl.useProgram(programAssistCam);
-                    // gl.useProgram(program);
                     for (i = 0, len = nodes.length; i < len; ++i) {
                         if (isDrawNodes[i]) {
                             node = nodes[i];

--- a/occlusion.html
+++ b/occlusion.html
@@ -436,11 +436,11 @@
             vec4.transformMat4(tmpVec4b, tmpVec4b, tmpMat4);
             
             vec4.sub(tmpVec4a, tmpVec4a, tmpVec4b);
-            if (tmpVec4a[0] !== 0) {
-                return tmpVec4a[0];
-            }
             if (tmpVec4a[2] !== 0) {
                 return tmpVec4a[2];
+            }
+            if (tmpVec4a[0] !== 0) {
+                return tmpVec4a[0];
             }
             return -tmpVec4a[1];
         });

--- a/occlusion.html
+++ b/occlusion.html
@@ -472,6 +472,7 @@
         var angleY = 0;
 
         var image = new Image();
+        var firstFrame = true;
 
         image.onload = function() {
             var texture = gl.createTexture();
@@ -493,7 +494,7 @@
             gl.uniform1i(texLocation, 0);
 
             var rotationMatrix = mat4.create();
-            var node, bbox;
+            var node, bbox, isVisible = true;
 
             function draw() {
                 // angleX += 0.01;
@@ -508,13 +509,15 @@
                 // gl.clear(gl.COLOR_BUFFER_BIT);
                 // gl.drawArrays(gl.TRIANGLES, 0, numVertices);
 
+                gl.colorMask(true, true, true, true);
+                gl.depthMask(true);
                 gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
                 for (var i = 0, len = nodes.length; i < len; ++i) {
                     node = nodes[i];
                     bbox = node.bbox;
 
-                    node.rotate[1] += 0.002;
+                    node.rotate[1] += 0.01;
 
                     utils.xformMatrix(node.modelMatrix, node.translate, null, node.scale);
                     mat4.fromYRotation(rotationMatrix, node.rotate[1]);
@@ -523,44 +526,59 @@
                     
 
                     // use occlusion query with drawing bounding box
-                    // gl.colorMask(false, false, false, false);
-                    // gl.depthMask(false);
+                    gl.colorMask(false, false, false, false);
+                    gl.depthMask(false);
                     gl.useProgram(programBBox);
                     gl.bindVertexArray(node.vaobbox);
 
                     gl.uniformMatrix4fv(modelMatrixLocationBBox, false, node.modelMatrix);
                     
+                    if (!firstFrame) {
+                        if (gl.getQueryParameter(node.query, gl.QUERY_RESULT_AVAILABLE)) {
+                            // A query's result is never available in the same frame
+                            // the query was issued.  Try in the next frame.
+                            var samplesPassed = gl.getQueryParameter(node.query, gl.QUERY_RESULT);
+
+                            if (samplesPassed == 0) {
+                                // console.log('invisible node ' + i);
+                                isVisible = false;
+                            }
+                            else
+                            {
+                                // console.log('!!!visible node ' + i);
+                                isVisible = true;
+                            }
+                        }
+                    }
+                    
+
                     gl.beginQuery(gl.ANY_SAMPLES_PASSED, node.query);
                     gl.drawArrays(gl.TRIANGLES, 0, node.bboxNumVertices);
                     gl.endQuery(gl.ANY_SAMPLES_PASSED);
 
-                    if (gl.getQueryParameter(node.query, gl.QUERY_RESULT_AVAILABLE)) {
-                        // A query's result is never available in the same frame
-                        // the query was issued.  Try in the next frame.
-                        var samplesPassed = gl.getQueryParameter(node.query, gl.QUERY_RESULT);
+                    
+                    if (isVisible) {
+                        gl.colorMask(true, true, true, true);
+                        gl.depthMask(true);
+                        gl.useProgram(program);
+                        gl.bindVertexArray(node.vao);
 
-                        if (samplesPassed == 0) {
-                            console.log('invisible node ' + i);
-                            continue;
+                        gl.uniformMatrix4fv(modelMatrixLocation, false, node.modelMatrix);
+                        // modelMatrixData.set(node.modelMatrix, i * 16);
+
+                        if (node.indicesLength) {
+                            gl.drawElements(gl.TRIANGLES, node.indicesLength, gl.UNSIGNED_SHORT, 0);
+                        } else {
+                            gl.drawArrays(gl.TRIANGLES, 0, node.numVertices);
                         }
                     }
-
-                    // gl.colorMask(true, true, true, true);
-                    // gl.depthMask(true);
-                    // gl.useProgram(program);
-                    // gl.bindVertexArray(node.vao);
-
-                    // gl.uniformMatrix4fv(modelMatrixLocation, false, node.modelMatrix);
-                    // // modelMatrixData.set(node.modelMatrix, i * 16);
-
-                    // if (node.indicesLength) {
-                    //     gl.drawElements(gl.TRIANGLES, node.indicesLength, gl.UNSIGNED_SHORT, 0);
-                    // } else {
-                    //     gl.drawArrays(gl.TRIANGLES, 0, node.numVertices);
-                    // }
+                    
                     
                 }
                 
+                if (firstFrame) {
+                    firstFrame = false;
+                }
 
                 requestAnimationFrame(draw);
             }

--- a/occlusion.html
+++ b/occlusion.html
@@ -21,6 +21,11 @@
   IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
+<!-- 
+    Occlusion culling algorithm (naive version) from 
+    https://developer.nvidia.com/gpugems/GPUGems2/gpugems2_chapter06.html
+    https://developer.nvidia.com/gpugems/GPUGems/gpugems_ch29.html
+ -->
 <html>
 <head>
     <title>WebGL 2 Example: Occlusion culling using occlusion query</title>

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -335,6 +335,39 @@
             uvs: uvs,
             indices: indices
           };
+        },
+
+        computeBoundingBox: function (position, options) {
+          options = options || {};
+          var geo = options.geo || false;
+
+          var res = {
+            min: vec3.create(),
+            max: vec3.create()
+          };
+          vec3.set(res.min, Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY);
+          vec3.set(res.max, Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY);
+          for ( var i = 0, len = position.length; i < len; i+=3 ) {
+            res.min[0] = Math.min(position[i], res.min[0]);
+            res.max[0] = Math.max(position[i], res.max[0]);
+            res.min[1] = Math.min(position[i], res.min[1]);
+            res.max[1] = Math.max(position[i], res.max[1]);
+            res.min[2] = Math.min(position[i], res.min[2]);
+            res.max[2] = Math.max(position[i], res.max[2]);
+          }
+
+          if (geo) {
+            var size = vec3.create();
+            vec3.subtract(size, res.max, res.min);
+            res.bbox = utils.createBox({
+              position: res.min,
+              width: size[0],
+              height: size[1],
+              depth: size[2]
+            });
+          }
+
+          return res;
         }
     }
 


### PR DESCRIPTION
Instead of pico.js, try something easier first...

Though the functionality is finished, there's a problem:
Seems like when there are too many nodes i.e. too many queries being active. Sometimes the `gl.getQueryParameter(node.query, gl.QUERY_RESULT_AVAILABLE)` doesn't behave as expected, looks like it returns a true when it is not ready (I'm still not sure where exactly the issue is). You will notice the assist cam view is flashing when it is not working correctly. It seems to me that when the time per frame increases to a certain threshold, gl will fail to maintain the query behavior, though according to opengl es 3 spec, querying `QUERY_RESULT_AVAILABLE` multiple times will eventually returns a true. 

You can play with the `NUM_NODES` and try refreshing the page multiple times to get a properly running instance, and a incorrectly running one. Based on my experiment on Win10, firefox seems to have a higher probability running correctly, compared to chrome (not disabling angle). I think it might be appropriate to ask Ken sometime about more details and posssible workaround.